### PR TITLE
Add types

### DIFF
--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -4,6 +4,7 @@ import { z } from 'zod';
 import pThrottle from 'p-throttle';
 
 import * as jotform from './index.js';
+import { SubmissionStatus } from './types.js';
 
 const TEST_FORM_ID = '232143945675058';
 
@@ -121,7 +122,7 @@ describe('getForms()', () => {
       )
       .parse(response);
 
-    const testForm = parsedResponse.find((form: { id: string }) => form.id === TEST_FORM_ID);
+    const testForm = parsedResponse.find((form) => form.id === TEST_FORM_ID);
 
     expect(testForm).toBeDefined();
   });
@@ -836,16 +837,23 @@ describe('getSubmissions()', () => {
   it('returns submissions data properly', async () => {
     const response = await jotform.getSubmissions({
       filter: {
-        status: 'ACTIVE',
+        status: SubmissionStatus.ACTIVE,
       },
     });
 
     expect(response).toMatchObject(expect.any(Array));
 
-    const anyResponse = z.any().parse(response);
-
-    const testFormSubmission = anyResponse.find(
-      (submission: { id: string }) => submission.id === TEST_FORM_SUBMISSION_ID,
+    const parsedResponse = z
+      .array(
+        z.object({
+          id: z.string(),
+          status: z.enum([SubmissionStatus.ACTIVE]),
+        }),
+      )
+      .parse(response);
+    
+      const testFormSubmission = parsedResponse.find(
+      (submission) => submission.id === TEST_FORM_SUBMISSION_ID,
     );
 
     expect(testFormSubmission).toBeDefined();

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -4,7 +4,7 @@ import { z } from 'zod';
 import pThrottle from 'p-throttle';
 
 import * as jotform from './index.js';
-import { SubmissionStatus } from './types.js';
+import { FormStatus, PlanName, SubmissionStatus } from './types.js';
 
 const TEST_FORM_ID = '232143945675058';
 
@@ -95,10 +95,10 @@ describe('getUser()', () => {
 
 describe('getPlan()', () => {
   it('returns plan data properly', async () => {
-    const response = await jotform.getPlan('FREE');
+    const response = await jotform.getPlan(PlanName.FREE);
 
     expect(response).toMatchObject({
-      name: 'FREE',
+      name: PlanName.FREE,
     });
   });
 });
@@ -109,7 +109,7 @@ describe('getPlan()', () => {
 
 describe('getForms()', () => {
   it('returns forms data properly', async () => {
-    const response = await jotform.getForms({ filter: { status: 'ENABLED' } });
+    const response = await jotform.getForms({ filter: { status: FormStatus.ENABLED } });
 
     expect(response).toMatchObject(expect.any(Array));
 
@@ -117,7 +117,7 @@ describe('getForms()', () => {
       .array(
         z.object({
           id: z.string(),
-          status: z.enum(['ENABLED']),
+          status: z.enum([FormStatus.ENABLED]),
         }),
       )
       .parse(response);
@@ -851,8 +851,8 @@ describe('getSubmissions()', () => {
         }),
       )
       .parse(response);
-    
-      const testFormSubmission = parsedResponse.find(
+
+    const testFormSubmission = parsedResponse.find(
       (submission) => submission.id === TEST_FORM_SUBMISSION_ID,
     );
 

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -112,10 +112,14 @@ describe('getForms()', () => {
 
     expect(response).toMatchObject(expect.any(Array));
 
-    const parsedResponse = z.array(z.object({
-      id: z.string(),
-      status: z.enum(["ENABLED"])
-    })).parse(response);
+    const parsedResponse = z
+      .array(
+        z.object({
+          id: z.string(),
+          status: z.enum(['ENABLED']),
+        }),
+      )
+      .parse(response);
 
     const testForm = parsedResponse.find((form: { id: string }) => form.id === TEST_FORM_ID);
 

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -112,9 +112,12 @@ describe('getForms()', () => {
 
     expect(response).toMatchObject(expect.any(Array));
 
-    const anyResponse = z.any().parse(response);
+    const parsedResponse = z.array(z.object({
+      id: z.string(),
+      status: z.enum(["ENABLED"])
+    })).parse(response);
 
-    const testForm = anyResponse.find((form: { id: string }) => form.id === TEST_FORM_ID);
+    const testForm = parsedResponse.find((form: { id: string }) => form.id === TEST_FORM_ID);
 
     expect(testForm).toBeDefined();
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import { serialize } from 'object-to-formdata';
+import type { Form } from './types.js';
 
 type Options = {
   /**
@@ -420,9 +421,9 @@ type GetFormsQuery = {
  * @link https://api.jotform.com/docs/#user-forms
  * @param {GetFormsQuery} [query]
  * @param {HeadersInit} [customHeaders]
- * @returns {Promise<unknown>}
+ * @returns {Promise<Form[]>}
  */
-export function getForms(query: GetFormsQuery = {}, customHeaders?: HeadersInit): Promise<unknown> {
+export function getForms(query: GetFormsQuery = {}, customHeaders?: HeadersInit): Promise<Form[]> {
   const { filter, offset, limit, orderby, direction, fullText } = query;
 
   if (filter && typeof filter !== 'object') {
@@ -443,7 +444,7 @@ export function getForms(query: GetFormsQuery = {}, customHeaders?: HeadersInit)
     direction,
   });
 
-  const promise = get(requestUrl, customHeaders);
+  const promise = get<Form[]>(requestUrl, customHeaders);
   return promise;
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,9 @@
 import { serialize } from 'object-to-formdata';
 import type {
   Form,
+  FormFile,
   FormProperties,
+  FormReport,
   Plan,
   PlanName,
   Question,
@@ -577,9 +579,9 @@ export function cloneForm(formID: string, customHeaders?: HeadersInit): Promise<
  * @link https://api.jotform.com/docs/#form-id-files
  * @param {string} formID
  * @param {HeadersInit} [customHeaders]
- * @returns {Promise<unknown>}
+ * @returns {Promise<FormFile[]>}
  */
-export function getFormFiles(formID: string, customHeaders?: HeadersInit): Promise<unknown> {
+export function getFormFiles(formID: string, customHeaders?: HeadersInit): Promise<FormFile[]> {
   if (typeof formID === 'undefined' || formID === null) {
     throw new Error('formID is required');
   }
@@ -587,7 +589,7 @@ export function getFormFiles(formID: string, customHeaders?: HeadersInit): Promi
   const endPoint = `/form/${formID}/files`;
   const requestUrl = getRequestUrl(endPoint);
 
-  const promise = get(requestUrl, customHeaders);
+  const promise = get<FormFile[]>(requestUrl, customHeaders);
   return promise;
 }
 
@@ -604,7 +606,10 @@ export function getFormFiles(formID: string, customHeaders?: HeadersInit): Promi
  * @param {HeadersInit} [customHeaders]
  * @returns {Promise<FormProperties>}
  */
-export function getFormProperties(formID: string, customHeaders?: HeadersInit): Promise<FormProperties> {
+export function getFormProperties(
+  formID: string,
+  customHeaders?: HeadersInit,
+): Promise<FormProperties> {
   if (typeof formID === 'undefined' || formID === null) {
     throw new Error('formID is required');
   }
@@ -717,7 +722,10 @@ export function addFormProperties(
  * @param {HeadersInit} [customHeaders]
  * @returns {Promise<{[question: string]: Question}>}
  */
-export function getFormQuestions(formID: string, customHeaders?: HeadersInit): Promise<{[question: string]: Question}> {
+export function getFormQuestions(
+  formID: string,
+  customHeaders?: HeadersInit,
+): Promise<{ [question: string]: Question }> {
   if (typeof formID === 'undefined' || formID === null) {
     throw new Error('formID is required');
   }
@@ -725,7 +733,7 @@ export function getFormQuestions(formID: string, customHeaders?: HeadersInit): P
   const endPoint = `/form/${formID}/questions`;
   const requestUrl = getRequestUrl(endPoint);
 
-  const promise = get<{[question: string]: Question}>(requestUrl, customHeaders);
+  const promise = get<{ [question: string]: Question }>(requestUrl, customHeaders);
   return promise;
 }
 
@@ -835,7 +843,7 @@ export function deleteFormQuestion(
   formID: string,
   questionID: string,
   customHeaders?: HeadersInit,
-): Promise<unknown> {
+): Promise<string> {
   if (typeof formID === 'undefined' || formID === null) {
     throw new Error('formID is required');
   }
@@ -847,7 +855,7 @@ export function deleteFormQuestion(
   const endPoint = `/form/${formID}/question/${questionID}`;
   const requestUrl = getRequestUrl(endPoint);
 
-  const promise = del(requestUrl, customHeaders);
+  const promise = del<string>(requestUrl, customHeaders);
   return promise;
 }
 
@@ -862,9 +870,9 @@ export function deleteFormQuestion(
  * @link https://api.jotform.com/docs/#form-id-reports
  * @param {string} formID
  * @param {HeadersInit} [customHeaders]
- * @returns {Promise<unknown>}
+ * @returns {Promise<FormReport[]>}
  */
-export function getFormReports(formID: string, customHeaders?: HeadersInit): Promise<unknown> {
+export function getFormReports(formID: string, customHeaders?: HeadersInit): Promise<FormReport[]> {
   if (typeof formID === 'undefined' || formID === null) {
     throw new Error('formID is required');
   }
@@ -872,7 +880,7 @@ export function getFormReports(formID: string, customHeaders?: HeadersInit): Pro
   const endPoint = `/form/${formID}/reports`;
   const requestUrl = getRequestUrl(endPoint);
 
-  const promise = get(requestUrl, customHeaders);
+  const promise = get<FormReport[]>(requestUrl, customHeaders);
   return promise;
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import { serialize } from 'object-to-formdata';
-import type { Form, UserSettings } from './types.js';
+import type { Form, Plan, PlanName, Submission, UpdateUserSettings, User, UserSettings, UserUsage } from './types.js';
 
 type Options = {
   /**
@@ -297,7 +297,7 @@ export function getSettings(customHeaders?: HeadersInit): Promise<UserSettings> 
  * @returns {Promise<unknown>}
  */
 export function updateSettings(
-  settingsData: unknown,
+  settingsData: UpdateUserSettings,
   customHeaders?: HeadersInit,
 ): Promise<unknown> {
   if (typeof settingsData !== 'object' || settingsData === null) {
@@ -334,13 +334,13 @@ export function getSubusers(customHeaders?: HeadersInit): Promise<unknown> {
  * @description Get number of form submissions received this month. Also, get number of SSL form submissions, payment form submissions and upload space used by user.
  * @link https://api.jotform.com/docs/#user-usage
  * @param {HeadersInit} [customHeaders]
- * @returns {Promise<unknown>}
+ * @returns {Promise<UserUsage>}
  */
-export function getUsage(customHeaders?: HeadersInit): Promise<unknown> {
+export function getUsage(customHeaders?: HeadersInit): Promise<UserUsage> {
   const endPoint = '/user/usage';
   const requestUrl = getRequestUrl(endPoint);
 
-  const promise = get(requestUrl, customHeaders);
+  const promise = get<UserUsage>(requestUrl, customHeaders);
   return promise;
 }
 
@@ -350,13 +350,13 @@ export function getUsage(customHeaders?: HeadersInit): Promise<unknown> {
  * @description Get user account details for this Jotform user. Including user account type, avatar URL, name, email, website URL.
  * @link https://api.jotform.com/docs/#user
  * @param {HeadersInit} [customHeaders]
- * @returns {Promise<unknown>}
+ * @returns {Promise<User>}
  */
-export function getUser(customHeaders?: HeadersInit): Promise<unknown> {
+export function getUser(customHeaders?: HeadersInit): Promise<User> {
   const endPoint = '/user';
   const requestUrl = getRequestUrl(endPoint);
 
-  const promise = get(requestUrl, customHeaders);
+  const promise = get<User>(requestUrl, customHeaders);
   return promise;
 }
 
@@ -364,9 +364,9 @@ export function getUser(customHeaders?: HeadersInit): Promise<unknown> {
  * Get details of a plan
  *
  * @description Get limit and prices of a plan.
- * @param {string} planName
+ * @param {PlanName} planName
  */
-export function getPlan(planName: string, customHeaders?: HeadersInit): Promise<unknown> {
+export function getPlan(planName: string, customHeaders?: HeadersInit): Promise<Plan> {
   if (planName === undefined) {
     throw new Error('Plan name is undefined');
   }
@@ -374,7 +374,7 @@ export function getPlan(planName: string, customHeaders?: HeadersInit): Promise<
   const endPoint = `/system/plan/${planName}`;
   const requestUrl = getRequestUrl(endPoint);
 
-  const promise = get(requestUrl, customHeaders);
+  const promise = get<Plan>(requestUrl, customHeaders);
   return promise;
 }
 
@@ -976,13 +976,13 @@ type GetFormSubmissionsQuery = {
  * @param {string} formID
  * @param {GetFormSubmissionsQuery} [query]
  * @param {HeadersInit} [customHeaders]
- * @returns {Promise<unknown>}
+ * @returns {Promise<Submission[]>}
  */
 export function getFormSubmissions(
   formID: string,
   query: GetFormSubmissionsQuery = {},
   customHeaders?: HeadersInit,
-): Promise<unknown> {
+): Promise<Submission[]> {
   if (typeof formID === 'undefined' || formID === null) {
     throw new Error('formID is required');
   }
@@ -1006,7 +1006,7 @@ export function getFormSubmissions(
     direction,
   });
 
-  const promise = get(requestUrl, customHeaders);
+  const promise = get<Submission[]>(requestUrl, customHeaders);
   return promise;
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import { serialize } from 'object-to-formdata';
-import type { Form } from './types.js';
+import type { Form, UserSettings } from './types.js';
 
 type Options = {
   /**
@@ -277,13 +277,13 @@ export function getHistory(
  * @description Get user's time zone and language.
  * @link https://api.jotform.com/docs/#user-settings
  * @param {HeadersInit} [customHeaders]
- * @returns {Promise<unknown>}
+ * @returns {Promise<UserSettings>}
  */
-export function getSettings(customHeaders?: HeadersInit): Promise<unknown> {
+export function getSettings(customHeaders?: HeadersInit): Promise<UserSettings> {
   const endPoint = '/user/settings';
   const requestUrl = getRequestUrl(endPoint);
 
-  const promise = get(requestUrl, customHeaders);
+  const promise = get<UserSettings>(requestUrl, customHeaders);
   return promise;
 }
 
@@ -455,9 +455,9 @@ export function getForms(query: GetFormsQuery = {}, customHeaders?: HeadersInit)
  * @link https://api.jotform.com/docs/#form-id
  * @param {string} formID
  * @param {HeadersInit} [customHeaders]
- * @returns {Promise<unknown>}
+ * @returns {Promise<Form>}
  */
-export function getForm(formID: string, customHeaders?: HeadersInit): Promise<unknown> {
+export function getForm(formID: string, customHeaders?: HeadersInit): Promise<Form> {
   if (typeof formID === 'undefined' || formID === null) {
     throw new Error('formID is required');
   }
@@ -465,7 +465,7 @@ export function getForm(formID: string, customHeaders?: HeadersInit): Promise<un
   const endPoint = `/form/${formID}`;
   const requestUrl = getRequestUrl(endPoint);
 
-  const promise = get(requestUrl, customHeaders);
+  const promise = get<Form>(requestUrl, customHeaders);
   return promise;
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,16 @@
 import { serialize } from 'object-to-formdata';
-import type { Form, Plan, PlanName, Submission, UpdateUserSettings, User, UserSettings, UserUsage } from './types.js';
+import type {
+  Form,
+  FormProperties,
+  Plan,
+  PlanName,
+  Question,
+  Submission,
+  UpdateUserSettings,
+  User,
+  UserSettings,
+  UserUsage,
+} from './types.js';
 
 type Options = {
   /**
@@ -366,7 +377,7 @@ export function getUser(customHeaders?: HeadersInit): Promise<User> {
  * @description Get limit and prices of a plan.
  * @param {PlanName} planName
  */
-export function getPlan(planName: string, customHeaders?: HeadersInit): Promise<Plan> {
+export function getPlan(planName: PlanName, customHeaders?: HeadersInit): Promise<Plan> {
   if (planName === undefined) {
     throw new Error('Plan name is undefined');
   }
@@ -591,9 +602,9 @@ export function getFormFiles(formID: string, customHeaders?: HeadersInit): Promi
  * @link https://api.jotform.com/docs/#form-id-properties
  * @param {string} formID
  * @param {HeadersInit} [customHeaders]
- * @returns {Promise<unknown>}
+ * @returns {Promise<FormProperties>}
  */
-export function getFormProperties(formID: string, customHeaders?: HeadersInit): Promise<unknown> {
+export function getFormProperties(formID: string, customHeaders?: HeadersInit): Promise<FormProperties> {
   if (typeof formID === 'undefined' || formID === null) {
     throw new Error('formID is required');
   }
@@ -601,7 +612,7 @@ export function getFormProperties(formID: string, customHeaders?: HeadersInit): 
   const endPoint = `/form/${formID}/properties`;
   const requestUrl = getRequestUrl(endPoint);
 
-  const promise = get(requestUrl, customHeaders);
+  const promise = get<FormProperties>(requestUrl, customHeaders);
   return promise;
 }
 
@@ -704,9 +715,9 @@ export function addFormProperties(
  * @link https://api.jotform.com/docs/#form-id-questions
  * @param {string} formID
  * @param {HeadersInit} [customHeaders]
- * @returns {Promise<unknown>}
+ * @returns {Promise<{[question: string]: Question}>}
  */
-export function getFormQuestions(formID: string, customHeaders?: HeadersInit): Promise<unknown> {
+export function getFormQuestions(formID: string, customHeaders?: HeadersInit): Promise<{[question: string]: Question}> {
   if (typeof formID === 'undefined' || formID === null) {
     throw new Error('formID is required');
   }
@@ -714,7 +725,7 @@ export function getFormQuestions(formID: string, customHeaders?: HeadersInit): P
   const endPoint = `/form/${formID}/questions`;
   const requestUrl = getRequestUrl(endPoint);
 
-  const promise = get(requestUrl, customHeaders);
+  const promise = get<{[question: string]: Question}>(requestUrl, customHeaders);
   return promise;
 }
 
@@ -726,13 +737,13 @@ export function getFormQuestions(formID: string, customHeaders?: HeadersInit): P
  * @param {string} formID
  * @param {string} questionID
  * @param {HeadersInit} [customHeaders]
- * @returns {Promise<unknown>}
+ * @returns {Promise<Question>}
  */
 export function getFormQuestion(
   formID: string,
   questionID: string,
   customHeaders?: HeadersInit,
-): Promise<unknown> {
+): Promise<Question> {
   if (typeof formID === 'undefined' || formID === null) {
     throw new Error('formID is required');
   }
@@ -744,7 +755,7 @@ export function getFormQuestion(
   const endPoint = `/form/${formID}/question/${questionID}`;
   const requestUrl = getRequestUrl(endPoint);
 
-  const promise = get(requestUrl, customHeaders);
+  const promise = get<Question>(requestUrl, customHeaders);
   return promise;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,16 +1,60 @@
+enum UserStatus {
+  ACTIVE='ACTIVE',
+  DELETED='DELETED',
+  SUSPENDED='SUSPENDED'
+}
+export type UserSettings = {
+  username: string;
+  name: string;
+  email: string;
+  website: string;
+  time_zone: string;
+  account_type: string;
+  status: UserStatus;
+  created_at: string;
+  updated_at: string;
+  // "region": "US",
+  is_verified: "0" | '1',
+  // "usage": "https://api.jotform.com/user/usage",
+  company?: string;
+  // "new_users_campaign": "1740167520",
+  // "loginToGetSubmissions": "1",
+  // "loginToViewUploadedFiles": "1",
+  // "loginToViewSubmissionRSS": "1",
+  showJotFormPowered: '0' | '1';
+  // "defaultTheme": "5e6b428acc8c4e222d1beb91",
+  // "formListingsTestUser": "1",
+  // "users_campaign_extended": "new_users_campaign",
+  // "smartPDFFormCreation": "25801",
+  // "language": "en-US",
+  avatarUrl: string;
+  // "is2FAEnabled": false,
+  // "disableViewLimits": false
+}
+
+// Form
+enum FormStatus {
+  ENABLED='ENABLED',
+  DISABLED='DISABLED',
+  DELETED='DELETED'
+}
+enum FormType {
+  LEGACY='LEGACY',
+  CARD='CARD'
+}
 export type Form = {
-    id: string;
-    username: string;
-    title: string;
-    height: string;
-    status: "ENABLED" | "DISABLED" | "DELETED";
-    created_at: string;
-    updated_at: string;
-    last_submission: string | null;
-    new: string;
-    count: string;
-    type: "LEGACY" | "CARD";
-    favorite: "0" | "1";
-    archived: "0" | "1";
-    url: string;
+  id: string;
+  username: string;
+  title: string;
+  height: string;
+  status: FormStatus;
+  created_at: string;
+  updated_at: string;
+  last_submission: string | null;
+  new: string;
+  count: string;
+  type: FormType;
+  favorite: '0' | '1';
+  archived: '0' | '1';
+  url: string;
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,46 +1,99 @@
 enum UserStatus {
-  ACTIVE='ACTIVE',
-  DELETED='DELETED',
-  SUSPENDED='SUSPENDED'
+  ACTIVE = 'ACTIVE',
+  DELETED = 'DELETED',
+  SUSPENDED = 'SUSPENDED',
 }
-export type UserSettings = {
+enum Industry {
+  Education='Education',
+  WebDesign='Web Design',
+  Religious='Religious',
+  NonProfit='Non-Profit',
+  EventOrganizer='Event Organizer',
+  Marketing='Marketing',
+  WebDevelopment='Web Development',
+  Consultancy='Consultancy',
+  Photography='Photography',
+  SocialMedia='Social Media',
+  SmallBusiness='Small Business',
+  Sports='Sports',
+  RealEstate='Real Estate',
+  HumanResources='Human Resources',
+  Other='Other'
+}
+type BasicUser = {
   username: string;
   name: string;
   email: string;
-  website: string;
+  website?: string;
   time_zone: string;
   account_type: string;
   status: UserStatus;
   created_at: string;
   updated_at: string;
-  // "region": "US",
-  is_verified: "0" | '1',
-  // "usage": "https://api.jotform.com/user/usage",
+  region: string;
+  is_verified: '0' | '1';
+  usage: string;
   company?: string;
-  // "new_users_campaign": "1740167520",
-  // "loginToGetSubmissions": "1",
-  // "loginToViewUploadedFiles": "1",
-  // "loginToViewSubmissionRSS": "1",
+  industry?: Industry;
+  loginToGetSubmissions: '0' | '1';
+  loginToViewUploadedFiles: '0' | '1';
+  loginToViewSubmissionRSS: '0' | '1';
   showJotFormPowered: '0' | '1';
-  // "defaultTheme": "5e6b428acc8c4e222d1beb91",
-  // "formListingsTestUser": "1",
-  // "users_campaign_extended": "new_users_campaign",
-  // "smartPDFFormCreation": "25801",
-  // "language": "en-US",
+  language: string;
   avatarUrl: string;
-  // "is2FAEnabled": false,
-  // "disableViewLimits": false
+  is2FAEnabled: boolean;
+  disableViewLimits: boolean;
+}
+export type User = BasicUser & {
+  allowBoards: boolean;
+  allowDigest: boolean;
+  allowPrefills: boolean;
+  allowSign: boolean;
+  allowWorkflowFeatures: boolean;
+  allowAutoDeleteSubmissions: boolean;
+  teamsBetaUser: '0' | '1';
+  paymentNewProductManagement: boolean;
+  allowEncryptionV2: boolean;
+  allowNewCondition: boolean;
+  allowConditionsV2: boolean;
+  isFormBuilderNewShare: boolean;
+  isInputTableBetaUserEnabled: boolean;
+  allowMixedListing: boolean;
+  allowAIAgentFormFiller: boolean;
+  allowPaymentReusableForEnterprise: boolean;
+  isNewSMTPFlowEnabled: boolean;
+}
+export type UserSettings = BasicUser;
+export type UpdateUserSettings = {
+  name?: string;
+  email?: string;
+  website?: string;
+  time_zone?: string;
+  company?: string;
+  securityQuestion?: string;
+  securityAnswer?: string;
+  industry?: Industry;
+}
+export type UserUsage = {
+  username: string;
+ submissions: string;
+ ssl_submissions: string;
+ payments: string;
+ uploads: string;
+ mobile_submissions: string;
+ views: string;
+ api: number;
 }
 
 // Form
 enum FormStatus {
-  ENABLED='ENABLED',
-  DISABLED='DISABLED',
-  DELETED='DELETED'
+  ENABLED = 'ENABLED',
+  DISABLED = 'DISABLED',
+  DELETED = 'DELETED',
 }
 enum FormType {
-  LEGACY='LEGACY',
-  CARD='CARD'
+  LEGACY = 'LEGACY',
+  CARD = 'CARD',
 }
 export type Form = {
   id: string;
@@ -58,3 +111,79 @@ export type Form = {
   archived: '0' | '1';
   url: string;
 };
+
+// Submission
+export enum SubmissionStatus {
+  ACTIVE="ACTIVE",
+  OVERQUOTA="OVERQUOTA"
+}
+type Answer = {
+  name: string;
+  order: string;
+  type: string;
+  text: string;
+} & (
+  | {
+      answer: Record<string, string>;
+      prettyFormat?: string;
+    }
+  | {
+      answer: string;
+    }
+  | {}
+);
+export type Submission = {
+  id: string;
+  form_id: string;
+  ip: string;
+  created_at: string;
+  updated_at: string;
+  status: SubmissionStatus;
+  new: "0" | "1";
+  flag: "0" | "1";
+  notes: string;
+  answers: {
+    [answer: string]: Answer;
+  };
+  workflowStatus?: string;
+}
+
+// System
+export enum PlanName {
+  FREE='FREE',
+  BRONZE='BRONZE',
+  SILVER='SILVER',
+  GOLD='GOLD',
+  PLATINUM='PLATINUM'
+}
+export type Plan = {
+  name: PlanName;
+  limits: {
+      submissions: number;
+      overSubmissions: number;
+      sslSubmissions: number;
+      payments: number;
+      uploads: number;
+      tickets: number;
+      subusers: number;
+      api: number;
+      views: number;
+      formCount: number;
+      "hipaaCompliance": boolean;
+  }
+  "prices": {
+      "monthly": number;
+      "yearly": number;
+      "biyearly": number;
+    },
+    "plimusIDs": {
+      "monthly": number;
+      "yearly": number;
+      "biyearly": number;
+    },
+    "fastSpringURLs": {
+      "monthly": string;
+      "yearly": string;
+      "biyearly": string;
+    },
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,21 +4,21 @@ enum UserStatus {
   SUSPENDED = 'SUSPENDED',
 }
 enum Industry {
-  Education='Education',
-  WebDesign='Web Design',
-  Religious='Religious',
-  NonProfit='Non-Profit',
-  EventOrganizer='Event Organizer',
-  Marketing='Marketing',
-  WebDevelopment='Web Development',
-  Consultancy='Consultancy',
-  Photography='Photography',
-  SocialMedia='Social Media',
-  SmallBusiness='Small Business',
-  Sports='Sports',
-  RealEstate='Real Estate',
-  HumanResources='Human Resources',
-  Other='Other'
+  Education = 'Education',
+  WebDesign = 'Web Design',
+  Religious = 'Religious',
+  NonProfit = 'Non-Profit',
+  EventOrganizer = 'Event Organizer',
+  Marketing = 'Marketing',
+  WebDevelopment = 'Web Development',
+  Consultancy = 'Consultancy',
+  Photography = 'Photography',
+  SocialMedia = 'Social Media',
+  SmallBusiness = 'Small Business',
+  Sports = 'Sports',
+  RealEstate = 'Real Estate',
+  HumanResources = 'Human Resources',
+  Other = 'Other',
 }
 type BasicUser = {
   username: string;
@@ -43,7 +43,7 @@ type BasicUser = {
   avatarUrl: string;
   is2FAEnabled: boolean;
   disableViewLimits: boolean;
-}
+};
 export type User = BasicUser & {
   allowBoards: boolean;
   allowDigest: boolean;
@@ -62,7 +62,7 @@ export type User = BasicUser & {
   allowAIAgentFormFiller: boolean;
   allowPaymentReusableForEnterprise: boolean;
   isNewSMTPFlowEnabled: boolean;
-}
+};
 export type UserSettings = BasicUser;
 export type UpdateUserSettings = {
   name?: string;
@@ -73,20 +73,20 @@ export type UpdateUserSettings = {
   securityQuestion?: string;
   securityAnswer?: string;
   industry?: Industry;
-}
+};
 export type UserUsage = {
   username: string;
- submissions: string;
- ssl_submissions: string;
- payments: string;
- uploads: string;
- mobile_submissions: string;
- views: string;
- api: number;
-}
+  submissions: string;
+  ssl_submissions: string;
+  payments: string;
+  uploads: string;
+  mobile_submissions: string;
+  views: string;
+  api: number;
+};
 
 // Form
-enum FormStatus {
+export enum FormStatus {
   ENABLED = 'ENABLED',
   DISABLED = 'DISABLED',
   DELETED = 'DELETED',
@@ -94,6 +94,37 @@ enum FormStatus {
 enum FormType {
   LEGACY = 'LEGACY',
   CARD = 'CARD',
+}
+type FormEmail = {
+  body: string;
+  dirty: string;
+  from: string;
+  hideEmptyFields: "0" | '1';
+  html: "0" | '1';
+  lastQuestionID: string;
+  name: string;
+  pdfattachment: string;
+  replyTo: string;
+  "sendOnEdit": '0' | "1";
+  subject: string;
+  to: string;
+  type: string;
+  uploadAttachment: string;
+  uniqueID: string;
+}
+type FormString = {
+  [key: string]: string;
+}
+type Language = {
+  "detectUserLanguage": '0' | '1';
+  "firstPageOnly": '0' | '1';
+  options: string;
+  originalLanguage: string;
+  primaryLanguage: string;
+  "saveUserLanguage": '0' | '1';
+  showStatus: string;
+  theme: string;
+  version: string;
 }
 export type Form = {
   id: string;
@@ -111,11 +142,25 @@ export type Form = {
   archived: '0' | '1';
   url: string;
 };
+export type FormProperties = Form & {
+  pagetitle: string;
+  pagetitleChanged: string;
+  emails: FormEmail[];
+  formStrings: FormString[];
+  languages: Language[];
+}
+export type Question = {
+  order: string;
+  qid: string;
+  text: string;
+  name: string;
+  type: string;
+}
 
 // Submission
 export enum SubmissionStatus {
-  ACTIVE="ACTIVE",
-  OVERQUOTA="OVERQUOTA"
+  ACTIVE = 'ACTIVE',
+  OVERQUOTA = 'OVERQUOTA',
 }
 type Answer = {
   name: string;
@@ -128,9 +173,8 @@ type Answer = {
       prettyFormat?: string;
     }
   | {
-      answer: string;
+      answer?: string;
     }
-  | {}
 );
 export type Submission = {
   id: string;
@@ -139,51 +183,51 @@ export type Submission = {
   created_at: string;
   updated_at: string;
   status: SubmissionStatus;
-  new: "0" | "1";
-  flag: "0" | "1";
+  new: '0' | '1';
+  flag: '0' | '1';
   notes: string;
   answers: {
     [answer: string]: Answer;
   };
   workflowStatus?: string;
-}
+};
 
 // System
 export enum PlanName {
-  FREE='FREE',
-  BRONZE='BRONZE',
-  SILVER='SILVER',
-  GOLD='GOLD',
-  PLATINUM='PLATINUM'
+  FREE = 'FREE',
+  BRONZE = 'BRONZE',
+  SILVER = 'SILVER',
+  GOLD = 'GOLD',
+  PLATINUM = 'PLATINUM',
 }
 export type Plan = {
   name: PlanName;
   limits: {
-      submissions: number;
-      overSubmissions: number;
-      sslSubmissions: number;
-      payments: number;
-      uploads: number;
-      tickets: number;
-      subusers: number;
-      api: number;
-      views: number;
-      formCount: number;
-      "hipaaCompliance": boolean;
-  }
-  "prices": {
-      "monthly": number;
-      "yearly": number;
-      "biyearly": number;
-    },
-    "plimusIDs": {
-      "monthly": number;
-      "yearly": number;
-      "biyearly": number;
-    },
-    "fastSpringURLs": {
-      "monthly": string;
-      "yearly": string;
-      "biyearly": string;
-    },
-}
+    submissions: number;
+    overSubmissions: number;
+    sslSubmissions: number;
+    payments: number;
+    uploads: number;
+    tickets: number;
+    subusers: number;
+    api: number;
+    views: number;
+    formCount: number;
+    hipaaCompliance: boolean;
+  };
+  prices: {
+    monthly: number;
+    yearly: number;
+    biyearly: number;
+  };
+  plimusIDs: {
+    monthly: number;
+    yearly: number;
+    biyearly: number;
+  };
+  fastSpringURLs: {
+    monthly: string;
+    yearly: string;
+    biyearly: string;
+  };
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -99,33 +99,33 @@ type FormEmail = {
   body: string;
   dirty: string;
   from: string;
-  hideEmptyFields: "0" | '1';
-  html: "0" | '1';
+  hideEmptyFields: '0' | '1';
+  html: '0' | '1';
   lastQuestionID: string;
   name: string;
   pdfattachment: string;
   replyTo: string;
-  "sendOnEdit": '0' | "1";
+  sendOnEdit: '0' | '1';
   subject: string;
   to: string;
   type: string;
   uploadAttachment: string;
   uniqueID: string;
-}
+};
 type FormString = {
   [key: string]: string;
-}
+};
 type Language = {
-  "detectUserLanguage": '0' | '1';
-  "firstPageOnly": '0' | '1';
+  detectUserLanguage: '0' | '1';
+  firstPageOnly: '0' | '1';
   options: string;
   originalLanguage: string;
   primaryLanguage: string;
-  "saveUserLanguage": '0' | '1';
+  saveUserLanguage: '0' | '1';
   showStatus: string;
   theme: string;
   version: string;
-}
+};
 export type Form = {
   id: string;
   username: string;
@@ -148,14 +148,46 @@ export type FormProperties = Form & {
   emails: FormEmail[];
   formStrings: FormString[];
   languages: Language[];
-}
+};
 export type Question = {
   order: string;
   qid: string;
   text: string;
   name: string;
   type: string;
+};
+enum ListType {
+  excel = 'excel',
+  csv = 'csv',
+  grid = 'grid',
+  table = 'table',
+  calendar = 'calendar',
+  rss = 'rss',
+  visual = 'visual',
 }
+export type FormReport = {
+  id: string;
+  form_id: string;
+  title: string;
+  created_at: string;
+  updated_at: string | null;
+  url: string;
+  isProtected: boolean;
+  fields?: string;
+  list_type?: ListType;
+  status: 'ENABLED' | 'DELETED';
+  settings?: string;
+};
+export type FormFile = {
+  name: string;
+  type: string;
+  size: string;
+  username: string;
+  form_id: string;
+  submission_id: string;
+  date: string;
+  url: string;
+};
 
 // Submission
 export enum SubmissionStatus {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,16 @@
+export type Form = {
+    id: string;
+    username: string;
+    title: string;
+    height: string;
+    status: "ENABLED" | "DISABLED" | "DELETED";
+    created_at: string;
+    updated_at: string;
+    last_submission: string | null;
+    new: string;
+    count: string;
+    type: "LEGACY" | "CARD";
+    favorite: "0" | "1";
+    archived: "0" | "1";
+    url: string;
+};


### PR DESCRIPTION
Hi @wojtekmaj 👋

Thank you for creating this package. When creating the [Jotform Raycast extension](https://www.raycast.com/xmok/jotform) I found the main SDK by Jotform but that has no typing. Found this fork in the comments and it's much better. Unfortunately, there are no actual return types so this PR proposes to add Return types so we always know what a function is returning.

It is incomplete because I would like your feedback on how to structure it i.e. 

- would you like to keep everything in one file as previously or is my approach adequate?
- should we add comments for all fields of a type?
- should we modify the zod tests to be even more exact? (right now I have only changed 2 tests which use enums)

Apart from that there's no reason we can't have types in the package.

Best.