### PR TITLE
Replace live Jotform API tests with MSW

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,5 +101,3 @@ jobs:
 
       - name: Run tests
         run: yarn unit
-        env:
-          JOTFORM_API_KEY: ${{ secrets.JOTFORM_API_KEY }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: ['*']
+    branches: [main]
   pull_request:
     branches: [main]
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: ['*']
   pull_request:
     branches: [main]
 
@@ -100,6 +100,6 @@ jobs:
         run: yarn --immutable
 
       - name: Run tests
-        run: yarn unit --testNamePattern='label lifecycle'
+        run: yarn unit
         env:
           JOTFORM_API_KEY: ${{ secrets.JOTFORM_API_KEY }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,6 @@ jobs:
         run: yarn --immutable
 
       - name: Run tests
-        run: yarn unit
+        run: yarn unit --testNamePattern='label lifecycle'
         env:
           JOTFORM_API_KEY: ${{ secrets.JOTFORM_API_KEY }}

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "@wojtekmaj/async-array-utils": "^2.0.0",
     "husky": "^9.0.0",
     "msw": "^2.15.0",
-    "p-throttle": "^7.0.0",
     "typescript": "^7.0.2",
     "vitest": "^4.1.8",
     "zod": "^4.0.0"

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "@types/node": "*",
     "@wojtekmaj/async-array-utils": "^2.0.0",
     "husky": "^9.0.0",
+    "msw": "^2.15.0",
     "p-throttle": "^7.0.0",
     "typescript": "^7.0.2",
     "vitest": "^4.1.8",

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -25,11 +25,10 @@ const objectWithIdSchema = z.object({
 const objectWithQidSchema = z.object({ qid: z.number() });
 const objectWithSubmissionIdSchema = z.object({ submissionID: z.string() });
 
-// Jotform starts returning 502 responses from the label API after roughly 50 requests per minute.
-const perSecondThrottle = pThrottle({ limit: 1, interval: 1000, strict: true });
-const perMinuteThrottle = pThrottle({ limit: 50, interval: 60_000, strict: true });
+// Throttle fetch API calls to avoid rate limiting
+const throttle = pThrottle({ limit: 1, interval: 1000 });
 
-vi.stubGlobal('fetch', perMinuteThrottle(perSecondThrottle(fetch)));
+vi.stubGlobal('fetch', throttle(fetch));
 
 describe('index', () => {
   it('has options exported properly', () => {
@@ -760,184 +759,19 @@ describe('getLabels()', () => {
   });
 });
 
-describe('getLabel()', () => {
-  let createdLabelId: string;
-
-  beforeAll(async () => {
-    const response = await jotform.createLabel({ name: 'Test label', color: '#FFFFFF' });
-
-    const objectWithIdResponse = objectWithIdSchema.parse(response);
-
-    createdLabelId = objectWithIdResponse.id;
-  });
-
-  afterAll(async () => {
-    await jotform.deleteLabel(createdLabelId);
-  });
-
-  it('returns label data properly', async () => {
-    const response = await jotform.getLabel(createdLabelId);
-
-    expect(response).toMatchObject({
-      id: createdLabelId,
-      name: expect.any(String),
-    });
-  });
-});
-
-describe('createLabel()', () => {
-  const createdLabelIds: string[] = [];
-
-  afterAll(async () => {
-    await asyncForEach(createdLabelIds, async (labelId) => {
-      await jotform.deleteLabel(labelId);
-    });
-  });
-
-  it('creates label properly', async () => {
-    const response = await jotform.createLabel({ name: 'Another test label', color: '#DDDDDD' });
-
-    expect(response).toMatchObject({
-      id: expect.any(String),
-    });
-
-    const anyResponse = z.any().parse(response);
-
-    createdLabelIds.push(anyResponse.id);
-  });
-});
-
-describe('updateLabel()', () => {
-  let createdLabelId: string;
-
-  beforeAll(async () => {
-    const response = await jotform.createLabel({ name: 'Updatable label', color: '#ABCDEF' });
-
-    const objectWithIdResponse = objectWithIdSchema.parse(response);
-
-    createdLabelId = objectWithIdResponse.id;
-  });
-
-  afterAll(async () => {
-    await jotform.deleteLabel(createdLabelId);
-  });
-
-  it('updates label properly', async () => {
-    const response = await jotform.updateLabel(createdLabelId, {
-      name: 'Updated label',
-      color: '#123456',
-    });
-
-    expect(response).toMatchObject({
-      name: 'Updated label',
-      color: '#123456',
-    });
-  });
-});
-
-describe('getLabelResources()', () => {
-  let createdLabelId: string;
-
-  beforeAll(async () => {
-    const response = await jotform.createLabel({ name: 'Resources label', color: '#EEEEEE' });
-
-    const objectWithIdResponse = objectWithIdSchema.parse(response);
-
-    createdLabelId = objectWithIdResponse.id;
-  });
-
-  afterAll(async () => {
-    await jotform.deleteLabel(createdLabelId);
-  });
-
-  it('returns label resources properly', async () => {
-    const response = await jotform.getLabelResources(createdLabelId);
-
-    expect(response).toMatchObject(expect.any(Array));
-  });
-});
-
-describe('addResourcesToLabel()', () => {
+describe.sequential('label lifecycle', () => {
   const resource = {
     id: TEST_FORM_ID,
     type: 'form',
   } as const;
 
-  let createdLabelId: string;
+  let createdLabelId = '';
+  let createLabelResponse: unknown;
 
   beforeAll(async () => {
-    const response = await jotform.createLabel({ name: 'Add resource label', color: '#C0FFEE' });
+    createLabelResponse = await jotform.createLabel({ name: 'Test label', color: '#FFFFFF' });
 
-    const objectWithIdResponse = objectWithIdSchema.parse(response);
-
-    createdLabelId = objectWithIdResponse.id;
-  });
-
-  afterAll(async () => {
-    await jotform.deleteLabel(createdLabelId);
-  });
-
-  it('adds resource to label properly', async () => {
-    const response = await jotform.addResourcesToLabel(createdLabelId, resource);
-
-    expect(response).toMatchObject(expect.any(Array));
-
-    const anyResponse = z.any().parse(response);
-
-    const item = anyResponse[0];
-
-    expect(item).toMatchObject({
-      id: resource.id,
-      type: expect.any(String),
-    });
-  });
-});
-
-describe('removeResourcesFromLabel()', () => {
-  const resource = {
-    id: TEST_FORM_ID,
-    type: 'form',
-  } as const;
-
-  let createdLabelId: string;
-
-  beforeAll(async () => {
-    const response = await jotform.createLabel({ name: 'Remove resource label', color: '#BADA55' });
-
-    const objectWithIdResponse = objectWithIdSchema.parse(response);
-
-    createdLabelId = objectWithIdResponse.id;
-
-    await jotform.addResourcesToLabel(createdLabelId, resource);
-  });
-
-  afterAll(async () => {
-    await jotform.deleteLabel(createdLabelId);
-  });
-
-  it('removes resources from label properly', async () => {
-    const response = await jotform.removeResourcesFromLabel(createdLabelId, [resource]);
-
-    expect(response).toMatchObject(expect.any(Array));
-
-    const anyResponse = z.any().parse(response);
-
-    const item = anyResponse[0];
-
-    expect(item).toMatchObject({
-      id: resource.id,
-      type: expect.any(String),
-    });
-  });
-});
-
-describe('deleteLabel()', () => {
-  let createdLabelId: string;
-
-  beforeAll(async () => {
-    const response = await jotform.createLabel({ name: 'Disposable label', color: '#654321' });
-
-    const objectWithIdResponse = objectWithIdSchema.parse(response);
+    const objectWithIdResponse = objectWithIdSchema.parse(createLabelResponse);
 
     createdLabelId = objectWithIdResponse.id;
   });
@@ -948,12 +782,89 @@ describe('deleteLabel()', () => {
     }
   });
 
-  it('deletes label properly', async () => {
-    const response = await jotform.deleteLabel(createdLabelId);
+  describe('createLabel()', () => {
+    it('creates label properly', () => {
+      expect(createLabelResponse).toMatchObject({
+        id: createdLabelId,
+      });
+    });
+  });
 
-    expect(response).toBe(true);
+  describe('getLabel()', () => {
+    it('returns label data properly', async () => {
+      const response = await jotform.getLabel(createdLabelId);
 
-    createdLabelId = '';
+      expect(response).toMatchObject({
+        id: createdLabelId,
+        name: expect.any(String),
+      });
+    });
+  });
+
+  describe('updateLabel()', () => {
+    it('updates label properly', async () => {
+      const response = await jotform.updateLabel(createdLabelId, {
+        name: 'Updated label',
+        color: '#123456',
+      });
+
+      expect(response).toMatchObject({
+        name: 'Updated label',
+        color: '#123456',
+      });
+    });
+  });
+
+  describe('getLabelResources()', () => {
+    it('returns label resources properly', async () => {
+      const response = await jotform.getLabelResources(createdLabelId);
+
+      expect(response).toMatchObject(expect.any(Array));
+    });
+  });
+
+  describe('addResourcesToLabel()', () => {
+    it('adds resource to label properly', async () => {
+      const response = await jotform.addResourcesToLabel(createdLabelId, resource);
+
+      expect(response).toMatchObject(expect.any(Array));
+
+      const anyResponse = z.any().parse(response);
+
+      const item = anyResponse[0];
+
+      expect(item).toMatchObject({
+        id: resource.id,
+        type: expect.any(String),
+      });
+    });
+  });
+
+  describe('removeResourcesFromLabel()', () => {
+    it('removes resources from label properly', async () => {
+      const response = await jotform.removeResourcesFromLabel(createdLabelId, [resource]);
+
+      expect(response).toMatchObject(expect.any(Array));
+
+      const anyResponse = z.any().parse(response);
+
+      const item = anyResponse[0];
+
+      expect(item).toMatchObject({
+        id: resource.id,
+        type: expect.any(String),
+      });
+    });
+  });
+
+  describe('deleteLabel()', () => {
+    it('deletes label properly', async () => {
+      const response = await jotform.deleteLabel(createdLabelId);
+
+      expect(response).toBe(true);
+
+      createdLabelId = '';
+    });
   });
 });
 

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -35,7 +35,8 @@ describe('index', () => {
  * General
  */
 
-describe('getHistory()', () => {
+// API call takes ~12 seconds to complete, we can't wait this long
+describe.skip('getHistory()', () => {
   it('returns history data properly', async () => {
     const response = await jotform.getHistory();
 
@@ -65,9 +66,12 @@ describe('updateSettings()', () => {
   });
 });
 
-describe('getSubusers()', () => {
-  it('throws the authorization error returned by the API', async () => {
-    await expect(jotform.getSubusers()).rejects.toThrow('User is not Allowed');
+// Getting "User is not Allowed" error
+describe.skip('getSubusers()', () => {
+  it('returns subusers data properly', async () => {
+    const response = await jotform.getSubusers();
+
+    expect(response).toMatchObject(expect.any(Array));
   });
 });
 
@@ -455,11 +459,14 @@ describe('getFormReports()', () => {
   });
 });
 
-describe('getFormReport()', () => {
-  it('throws the authorization error returned by the API', async () => {
-    await expect(jotform.getFormReport(TEST_FORM_ID, TEST_REPORT_ID)).rejects.toThrow(
-      "You're not authorized to use (/report-id)",
-    );
+// Getting "You're not authorized to use (/report-id)" error
+describe.skip('getFormReport()', () => {
+  it('returns submission data properly', async () => {
+    const response = await jotform.getFormReport(TEST_FORM_ID, TEST_REPORT_ID);
+
+    expect(response).toMatchObject({
+      id: TEST_REPORT_ID,
+    });
   });
 });
 
@@ -746,22 +753,184 @@ describe('getLabels()', () => {
   });
 });
 
-describe.sequential('label lifecycle', () => {
+describe('getLabel()', () => {
+  let createdLabelId: string;
+
+  beforeAll(async () => {
+    const response = await jotform.createLabel({ name: 'Test label', color: '#FFFFFF' });
+
+    const objectWithIdResponse = objectWithIdSchema.parse(response);
+
+    createdLabelId = objectWithIdResponse.id;
+  });
+
+  afterAll(async () => {
+    await jotform.deleteLabel(createdLabelId);
+  });
+
+  it('returns label data properly', async () => {
+    const response = await jotform.getLabel(createdLabelId);
+
+    expect(response).toMatchObject({
+      id: createdLabelId,
+      name: expect.any(String),
+    });
+  });
+});
+
+describe('createLabel()', () => {
+  const createdLabelIds: string[] = [];
+
+  afterAll(async () => {
+    await asyncForEach(createdLabelIds, async (labelId) => {
+      await jotform.deleteLabel(labelId);
+    });
+  });
+
+  it('creates label properly', async () => {
+    const response = await jotform.createLabel({ name: 'Another test label', color: '#DDDDDD' });
+
+    expect(response).toMatchObject({
+      id: expect.any(String),
+    });
+
+    const anyResponse = z.any().parse(response);
+
+    createdLabelIds.push(anyResponse.id);
+  });
+});
+
+describe('updateLabel()', () => {
+  let createdLabelId: string;
+
+  beforeAll(async () => {
+    const response = await jotform.createLabel({ name: 'Updatable label', color: '#ABCDEF' });
+
+    const objectWithIdResponse = objectWithIdSchema.parse(response);
+
+    createdLabelId = objectWithIdResponse.id;
+  });
+
+  afterAll(async () => {
+    await jotform.deleteLabel(createdLabelId);
+  });
+
+  it('updates label properly', async () => {
+    const response = await jotform.updateLabel(createdLabelId, {
+      name: 'Updated label',
+      color: '#123456',
+    });
+
+    expect(response).toMatchObject({
+      name: 'Updated label',
+      color: '#123456',
+    });
+  });
+});
+
+describe('getLabelResources()', () => {
+  let createdLabelId: string;
+
+  beforeAll(async () => {
+    const response = await jotform.createLabel({ name: 'Resources label', color: '#EEEEEE' });
+
+    const objectWithIdResponse = objectWithIdSchema.parse(response);
+
+    createdLabelId = objectWithIdResponse.id;
+  });
+
+  afterAll(async () => {
+    await jotform.deleteLabel(createdLabelId);
+  });
+
+  it('returns label resources properly', async () => {
+    const response = await jotform.getLabelResources(createdLabelId);
+
+    expect(response).toMatchObject(expect.any(Array));
+  });
+});
+
+describe('addResourcesToLabel()', () => {
   const resource = {
     id: TEST_FORM_ID,
     type: 'form',
   } as const;
 
-  let createdLabelId = '';
-  let createLabelResponse: unknown;
+  let createdLabelId: string;
 
   beforeAll(async () => {
-    createLabelResponse = await jotform.createLabel({
-      name: 'Test label',
-      color: '#FFFFFF',
-    });
+    const response = await jotform.createLabel({ name: 'Add resource label', color: '#C0FFEE' });
 
-    const objectWithIdResponse = objectWithIdSchema.parse(createLabelResponse);
+    const objectWithIdResponse = objectWithIdSchema.parse(response);
+
+    createdLabelId = objectWithIdResponse.id;
+  });
+
+  afterAll(async () => {
+    await jotform.deleteLabel(createdLabelId);
+  });
+
+  it('adds resource to label properly', async () => {
+    const response = await jotform.addResourcesToLabel(createdLabelId, resource);
+
+    expect(response).toMatchObject(expect.any(Array));
+
+    const anyResponse = z.any().parse(response);
+
+    const item = anyResponse[0];
+
+    expect(item).toMatchObject({
+      id: resource.id,
+      type: expect.any(String),
+    });
+  });
+});
+
+describe('removeResourcesFromLabel()', () => {
+  const resource = {
+    id: TEST_FORM_ID,
+    type: 'form',
+  } as const;
+
+  let createdLabelId: string;
+
+  beforeAll(async () => {
+    const response = await jotform.createLabel({ name: 'Remove resource label', color: '#BADA55' });
+
+    const objectWithIdResponse = objectWithIdSchema.parse(response);
+
+    createdLabelId = objectWithIdResponse.id;
+
+    await jotform.addResourcesToLabel(createdLabelId, resource);
+  });
+
+  afterAll(async () => {
+    await jotform.deleteLabel(createdLabelId);
+  });
+
+  it('removes resources from label properly', async () => {
+    const response = await jotform.removeResourcesFromLabel(createdLabelId, [resource]);
+
+    expect(response).toMatchObject(expect.any(Array));
+
+    const anyResponse = z.any().parse(response);
+
+    const item = anyResponse[0];
+
+    expect(item).toMatchObject({
+      id: resource.id,
+      type: expect.any(String),
+    });
+  });
+});
+
+describe('deleteLabel()', () => {
+  let createdLabelId: string;
+
+  beforeAll(async () => {
+    const response = await jotform.createLabel({ name: 'Disposable label', color: '#654321' });
+
+    const objectWithIdResponse = objectWithIdSchema.parse(response);
 
     createdLabelId = objectWithIdResponse.id;
   });
@@ -772,89 +941,12 @@ describe.sequential('label lifecycle', () => {
     }
   });
 
-  describe('createLabel()', () => {
-    it('creates label properly', () => {
-      expect(createLabelResponse).toMatchObject({
-        id: createdLabelId,
-      });
-    });
-  });
+  it('deletes label properly', async () => {
+    const response = await jotform.deleteLabel(createdLabelId);
 
-  describe('getLabel()', () => {
-    it('returns label data properly', async () => {
-      const response = await jotform.getLabel(createdLabelId);
+    expect(response).toBe(true);
 
-      expect(response).toMatchObject({
-        id: createdLabelId,
-        name: expect.any(String),
-      });
-    });
-  });
-
-  describe('updateLabel()', () => {
-    it('updates label properly', async () => {
-      const response = await jotform.updateLabel(createdLabelId, {
-        name: 'Updated label',
-        color: '#123456',
-      });
-
-      expect(response).toMatchObject({
-        name: 'Updated label',
-        color: '#123456',
-      });
-    });
-  });
-
-  describe('getLabelResources()', () => {
-    it('returns label resources properly', async () => {
-      const response = await jotform.getLabelResources(createdLabelId);
-
-      expect(response).toMatchObject(expect.any(Array));
-    });
-  });
-
-  describe('addResourcesToLabel()', () => {
-    it('adds resource to label properly', async () => {
-      const response = await jotform.addResourcesToLabel(createdLabelId, resource);
-
-      expect(response).toMatchObject(expect.any(Array));
-
-      const anyResponse = z.any().parse(response);
-
-      const item = anyResponse[0];
-
-      expect(item).toMatchObject({
-        id: resource.id,
-        type: expect.any(String),
-      });
-    });
-  });
-
-  describe('removeResourcesFromLabel()', () => {
-    it('removes resources from label properly', async () => {
-      const response = await jotform.removeResourcesFromLabel(createdLabelId, [resource]);
-
-      expect(response).toMatchObject(expect.any(Array));
-
-      const anyResponse = z.any().parse(response);
-
-      const item = anyResponse[0];
-
-      expect(item).toMatchObject({
-        id: resource.id,
-        type: expect.any(String),
-      });
-    });
-  });
-
-  describe('deleteLabel()', () => {
-    it('deletes label properly', async () => {
-      const response = await jotform.deleteLabel(createdLabelId);
-
-      expect(response).toBe(true);
-
-      createdLabelId = '';
-    });
+    createdLabelId = '';
   });
 });
 
@@ -940,11 +1032,14 @@ describe('getReports()', () => {
   });
 });
 
-describe('getReport()', () => {
-  it('throws the authorization error returned by the API', async () => {
-    await expect(jotform.getReport(TEST_REPORT_ID)).rejects.toThrow(
-      "You're not authorized to use (/report-id)",
-    );
+// Getting "You're not authorized to use (/report-id)" error
+describe.skip('getReport()', () => {
+  it('returns report data properly', async () => {
+    const response = await jotform.getReport(TEST_REPORT_ID);
+
+    expect(response).toMatchObject({
+      id: TEST_REPORT_ID,
+    });
   });
 });
 

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -35,8 +35,7 @@ describe('index', () => {
  * General
  */
 
-// API call takes ~12 seconds to complete, we can't wait this long
-describe.skip('getHistory()', () => {
+describe('getHistory()', () => {
   it('returns history data properly', async () => {
     const response = await jotform.getHistory();
 

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -26,7 +26,7 @@ const objectWithQidSchema = z.object({ qid: z.number() });
 const objectWithSubmissionIdSchema = z.object({ submissionID: z.string() });
 
 // Throttle fetch API calls to avoid rate limiting
-const throttle = pThrottle({ limit: 1, interval: 1000 });
+const throttle = pThrottle({ limit: 1, interval: 2000, strict: true });
 
 vi.stubGlobal('fetch', throttle(fetch));
 

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -25,10 +25,11 @@ const objectWithIdSchema = z.object({
 const objectWithQidSchema = z.object({ qid: z.number() });
 const objectWithSubmissionIdSchema = z.object({ submissionID: z.string() });
 
-// Throttle fetch API calls to avoid rate limiting
-const throttle = pThrottle({ limit: 1, interval: 2000, strict: true });
+// Jotform starts returning 502 responses from the label API after roughly 50 requests per minute.
+const perSecondThrottle = pThrottle({ limit: 1, interval: 1000, strict: true });
+const perMinuteThrottle = pThrottle({ limit: 50, interval: 60_000, strict: true });
 
-vi.stubGlobal('fetch', throttle(fetch));
+vi.stubGlobal('fetch', perMinuteThrottle(perSecondThrottle(fetch)));
 
 describe('index', () => {
   it('has options exported properly', () => {

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -1,5 +1,7 @@
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 import { asyncForEach } from '@wojtekmaj/async-array-utils';
+import { HttpResponse, http } from 'msw';
+import { setupServer } from 'msw/node';
 import pThrottle from 'p-throttle';
 import { z } from 'zod';
 
@@ -760,16 +762,72 @@ describe('getLabels()', () => {
 });
 
 describe.sequential('label lifecycle', () => {
+  const createdLabel = {
+    id: 'created-label-id',
+    name: 'Test label',
+    color: '#FFFFFF',
+  };
   const resource = {
     id: TEST_FORM_ID,
     type: 'form',
   } as const;
+  const resourceBodySchema = z.object({
+    resources: z.array(
+      z.object({
+        id: z.string(),
+        type: z.string(),
+      }),
+    ),
+  });
+  const jotformResponse = (content: unknown) =>
+    HttpResponse.json({
+      responseCode: 200,
+      message: 'success',
+      content,
+    });
+  const server = setupServer(
+    http.post('https://api.jotform.com/label', async ({ request }) => {
+      const body = await request.formData();
+
+      return jotformResponse({
+        id: createdLabel.id,
+        name: body.get('name'),
+        color: body.get('color'),
+      });
+    }),
+    http.get('https://api.jotform.com/label/:labelId', ({ params }) =>
+      jotformResponse({
+        ...createdLabel,
+        id: params.labelId,
+      }),
+    ),
+    http.put('https://api.jotform.com/label/:labelId', async ({ request }) =>
+      jotformResponse(await request.json()),
+    ),
+    http.get('https://api.jotform.com/label/:labelId/resources', () => jotformResponse([])),
+    http.put('https://api.jotform.com/label/:labelId/add-resources', async ({ request }) => {
+      const body = resourceBodySchema.parse(await request.json());
+
+      return jotformResponse(body.resources);
+    }),
+    http.put('https://api.jotform.com/label/:labelId/remove-resources', async ({ request }) => {
+      const body = resourceBodySchema.parse(await request.json());
+
+      return jotformResponse(body.resources);
+    }),
+    http.delete('https://api.jotform.com/label/:labelId', () => jotformResponse(true)),
+  );
 
   let createdLabelId = '';
   let createLabelResponse: unknown;
 
   beforeAll(async () => {
-    createLabelResponse = await jotform.createLabel({ name: 'Test label', color: '#FFFFFF' });
+    server.listen({ onUnhandledRequest: 'bypass' });
+
+    createLabelResponse = await jotform.createLabel({
+      name: createdLabel.name,
+      color: createdLabel.color,
+    });
 
     const objectWithIdResponse = objectWithIdSchema.parse(createLabelResponse);
 
@@ -777,8 +835,12 @@ describe.sequential('label lifecycle', () => {
   });
 
   afterAll(async () => {
-    if (createdLabelId) {
-      await jotform.deleteLabel(createdLabelId);
+    try {
+      if (createdLabelId) {
+        await jotform.deleteLabel(createdLabelId);
+      }
+    } finally {
+      server.close();
     }
   });
 

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -1,8 +1,5 @@
-import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { asyncForEach } from '@wojtekmaj/async-array-utils';
-import { HttpResponse, http } from 'msw';
-import { setupServer } from 'msw/node';
-import pThrottle from 'p-throttle';
 import { z } from 'zod';
 
 import * as jotform from './index.js';
@@ -27,11 +24,6 @@ const objectWithIdSchema = z.object({
 const objectWithQidSchema = z.object({ qid: z.number() });
 const objectWithSubmissionIdSchema = z.object({ submissionID: z.string() });
 
-// Throttle fetch API calls to avoid rate limiting
-const throttle = pThrottle({ limit: 1, interval: 1000 });
-
-vi.stubGlobal('fetch', throttle(fetch));
-
 describe('index', () => {
   it('has options exported properly', () => {
     expect(jotform.options).toBeDefined();
@@ -43,8 +35,7 @@ describe('index', () => {
  * General
  */
 
-// API call takes ~12 seconds to complete, we can't wait this long
-describe.skip('getHistory()', () => {
+describe('getHistory()', () => {
   it('returns history data properly', async () => {
     const response = await jotform.getHistory();
 
@@ -74,12 +65,9 @@ describe('updateSettings()', () => {
   });
 });
 
-// Getting "User is not Allowed" error
-describe.skip('getSubusers()', () => {
-  it('returns subusers data properly', async () => {
-    const response = await jotform.getSubusers();
-
-    expect(response).toMatchObject(expect.any(Array));
+describe('getSubusers()', () => {
+  it('throws the authorization error returned by the API', async () => {
+    await expect(jotform.getSubusers()).rejects.toThrow('User is not Allowed');
   });
 });
 
@@ -467,14 +455,11 @@ describe('getFormReports()', () => {
   });
 });
 
-// Getting "You're not authorized to use (/report-id)" error
-describe.skip('getFormReport()', () => {
-  it('returns submission data properly', async () => {
-    const response = await jotform.getFormReport(TEST_FORM_ID, TEST_REPORT_ID);
-
-    expect(response).toMatchObject({
-      id: TEST_REPORT_ID,
-    });
+describe('getFormReport()', () => {
+  it('throws the authorization error returned by the API', async () => {
+    await expect(jotform.getFormReport(TEST_FORM_ID, TEST_REPORT_ID)).rejects.toThrow(
+      "You're not authorized to use (/report-id)",
+    );
   });
 });
 
@@ -762,71 +747,18 @@ describe('getLabels()', () => {
 });
 
 describe.sequential('label lifecycle', () => {
-  const createdLabel = {
-    id: 'created-label-id',
-    name: 'Test label',
-    color: '#FFFFFF',
-  };
   const resource = {
     id: TEST_FORM_ID,
     type: 'form',
   } as const;
-  const resourceBodySchema = z.object({
-    resources: z.array(
-      z.object({
-        id: z.string(),
-        type: z.string(),
-      }),
-    ),
-  });
-  const jotformResponse = (content: unknown) =>
-    HttpResponse.json({
-      responseCode: 200,
-      message: 'success',
-      content,
-    });
-  const server = setupServer(
-    http.post('https://api.jotform.com/label', async ({ request }) => {
-      const body = await request.formData();
-
-      return jotformResponse({
-        id: createdLabel.id,
-        name: body.get('name'),
-        color: body.get('color'),
-      });
-    }),
-    http.get('https://api.jotform.com/label/:labelId', ({ params }) =>
-      jotformResponse({
-        ...createdLabel,
-        id: params.labelId,
-      }),
-    ),
-    http.put('https://api.jotform.com/label/:labelId', async ({ request }) =>
-      jotformResponse(await request.json()),
-    ),
-    http.get('https://api.jotform.com/label/:labelId/resources', () => jotformResponse([])),
-    http.put('https://api.jotform.com/label/:labelId/add-resources', async ({ request }) => {
-      const body = resourceBodySchema.parse(await request.json());
-
-      return jotformResponse(body.resources);
-    }),
-    http.put('https://api.jotform.com/label/:labelId/remove-resources', async ({ request }) => {
-      const body = resourceBodySchema.parse(await request.json());
-
-      return jotformResponse(body.resources);
-    }),
-    http.delete('https://api.jotform.com/label/:labelId', () => jotformResponse(true)),
-  );
 
   let createdLabelId = '';
   let createLabelResponse: unknown;
 
   beforeAll(async () => {
-    server.listen({ onUnhandledRequest: 'bypass' });
-
     createLabelResponse = await jotform.createLabel({
-      name: createdLabel.name,
-      color: createdLabel.color,
+      name: 'Test label',
+      color: '#FFFFFF',
     });
 
     const objectWithIdResponse = objectWithIdSchema.parse(createLabelResponse);
@@ -835,12 +767,8 @@ describe.sequential('label lifecycle', () => {
   });
 
   afterAll(async () => {
-    try {
-      if (createdLabelId) {
-        await jotform.deleteLabel(createdLabelId);
-      }
-    } finally {
-      server.close();
+    if (createdLabelId) {
+      await jotform.deleteLabel(createdLabelId);
     }
   });
 
@@ -1012,14 +940,11 @@ describe('getReports()', () => {
   });
 });
 
-// Getting "You're not authorized to use (/report-id)" error
-describe.skip('getReport()', () => {
-  it('returns report data properly', async () => {
-    const response = await jotform.getReport(TEST_REPORT_ID);
-
-    expect(response).toMatchObject({
-      id: TEST_REPORT_ID,
-    });
+describe('getReport()', () => {
+  it('throws the authorization error returned by the API', async () => {
+    await expect(jotform.getReport(TEST_REPORT_ID)).rejects.toThrow(
+      "You're not authorized to use (/report-id)",
+    );
   });
 });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -113,10 +113,6 @@ async function sendRequest<T>(
     }
   })();
 
-  if (url.startsWith(`${currentOptions.url}/label`)) {
-    console.log('Label response headers:', Object.fromEntries(response.headers));
-  }
-
   if (!response.ok) {
     const errorMessage =
       (typeof responseBody === 'object' ? responseBody.message : responseBody) ||

--- a/src/index.ts
+++ b/src/index.ts
@@ -113,6 +113,10 @@ async function sendRequest<T>(
     }
   })();
 
+  if (url.startsWith(`${currentOptions.url}/label`)) {
+    console.log('Label response headers:', Object.fromEntries(response.headers));
+  }
+
   if (!response.ok) {
     const errorMessage =
       (typeof responseBody === 'object' ? responseBody.message : responseBody) ||

--- a/test/mockServer.ts
+++ b/test/mockServer.ts
@@ -22,22 +22,29 @@ const settings: Record<string, unknown> = {
   email: 'test@example.com',
   website: 'https://example.com',
 };
+
 const forms = new Map<string, Record<string, unknown>>([
   [TEST_FORM_ID, { id: TEST_FORM_ID, title: 'Test form', status: 'ENABLED' }],
 ]);
+
 const formProperties = new Map<string, Record<string, unknown>>([
   [TEST_FORM_ID, { pagetitle: 'Test form' }],
 ]);
+
 const questions = new Map<string, Record<string, unknown>>([
   [TEST_FORM_QUESTION_ID, { qid: Number(TEST_FORM_QUESTION_ID), type: 'control_textbox' }],
 ]);
+
 const reports = new Map<string, Record<string, unknown>>([
   [TEST_REPORT_ID, { id: TEST_REPORT_ID, title: 'Test report' }],
 ]);
+
 const submissions = new Map<string, Record<string, unknown>>([
   [TEST_FORM_SUBMISSION_ID, { id: TEST_FORM_SUBMISSION_ID, form_id: TEST_FORM_ID }],
 ]);
+
 const webhooks = new Map<string, string>();
+
 const labels = new Map<string, Record<string, unknown>>();
 
 function jotformResponse(content: unknown) {

--- a/test/mockServer.ts
+++ b/test/mockServer.ts
@@ -1,0 +1,356 @@
+import { HttpResponse, http } from 'msw';
+import { setupServer } from 'msw/node';
+
+export const API_URL: string = 'https://api.jotform.test';
+
+const TEST_FORM_ID = '232143945675058';
+const TEST_FORM_SUBMISSION_ID = '5747651132391058779';
+const TEST_FORM_QUESTION_ID = '1';
+const TEST_ROOT_LABEL_ID = '0198c14737e87f33877e374156563c7be95a';
+const TEST_LABEL_ID = '019a15aba90c7fc2a2f9b95959c72c8345cc';
+const TEST_SUBLABEL_ID = '019a15b168537cd0bec4853947b190efb857';
+const TEST_REPORT_ID = '232152641243042';
+
+let formSequence = 0;
+let questionSequence = 100;
+let reportSequence = 0;
+let submissionSequence = 0;
+let webhookSequence = 0;
+let labelSequence = 0;
+
+const settings: Record<string, unknown> = {
+  email: 'test@example.com',
+  website: 'https://example.com',
+};
+const forms = new Map<string, Record<string, unknown>>([
+  [TEST_FORM_ID, { id: TEST_FORM_ID, title: 'Test form', status: 'ENABLED' }],
+]);
+const formProperties = new Map<string, Record<string, unknown>>([
+  [TEST_FORM_ID, { pagetitle: 'Test form' }],
+]);
+const questions = new Map<string, Record<string, unknown>>([
+  [TEST_FORM_QUESTION_ID, { qid: Number(TEST_FORM_QUESTION_ID), type: 'control_textbox' }],
+]);
+const reports = new Map<string, Record<string, unknown>>([
+  [TEST_REPORT_ID, { id: TEST_REPORT_ID, title: 'Test report' }],
+]);
+const submissions = new Map<string, Record<string, unknown>>([
+  [TEST_FORM_SUBMISSION_ID, { id: TEST_FORM_SUBMISSION_ID, form_id: TEST_FORM_ID }],
+]);
+const webhooks = new Map<string, string>();
+const labels = new Map<string, Record<string, unknown>>();
+
+function jotformResponse(content: unknown) {
+  return HttpResponse.json({
+    responseCode: 200,
+    message: 'success',
+    content,
+  });
+}
+
+function jotformError(message: string) {
+  return HttpResponse.json({
+    responseCode: 401,
+    message,
+    content: [],
+  });
+}
+
+async function getFormData(request: Request): Promise<Record<string, string>> {
+  const formData = await request.formData();
+
+  return Object.fromEntries(Array.from(formData.entries(), ([key, value]) => [key, String(value)]));
+}
+
+function getOrCreateProperties(formId: string): Record<string, unknown> {
+  const properties = formProperties.get(formId) ?? { pagetitle: 'Test form' };
+
+  formProperties.set(formId, properties);
+
+  return properties;
+}
+
+function createForm(): Record<string, unknown> {
+  formSequence += 1;
+
+  const id = `created-form-${formSequence}`;
+  const form = { id, title: 'Test form', status: 'ENABLED' };
+
+  forms.set(id, form);
+
+  return form;
+}
+
+function createQuestion(question: Record<string, unknown> = {}): Record<string, unknown> {
+  questionSequence += 1;
+
+  const createdQuestion = { qid: questionSequence, ...question };
+
+  questions.set(String(questionSequence), createdQuestion);
+
+  return createdQuestion;
+}
+
+function createReport(): Record<string, unknown> {
+  reportSequence += 1;
+
+  const id = `created-report-${reportSequence}`;
+  const report = { id, title: 'Test report' };
+
+  reports.set(id, report);
+
+  return report;
+}
+
+function createSubmission(): Record<string, unknown> {
+  submissionSequence += 1;
+
+  const submissionID = `created-submission-${submissionSequence}`;
+  const submission = { id: submissionID, submissionID, form_id: TEST_FORM_ID };
+
+  submissions.set(submissionID, submission);
+
+  return submission;
+}
+
+export const server: ReturnType<typeof setupServer> = setupServer(
+  http.get(`${API_URL}/user/history`, () => jotformResponse([])),
+  http.get(`${API_URL}/user/settings`, () => jotformResponse(settings)),
+  http.post(`${API_URL}/user/settings`, async ({ request }) => {
+    Object.assign(settings, await getFormData(request));
+
+    return jotformResponse(settings);
+  }),
+  http.get(`${API_URL}/user/subusers`, () => jotformError('User is not Allowed')),
+  http.get(`${API_URL}/user/usage`, () => jotformResponse({ api: 0 })),
+  http.get(`${API_URL}/user`, () => jotformResponse({ email: 'test@example.com' })),
+  http.get(`${API_URL}/system/plan/:planName`, ({ params }) =>
+    jotformResponse({ name: params.planName }),
+  ),
+
+  http.get(`${API_URL}/user/forms`, () => jotformResponse(Array.from(forms.values()))),
+  http.post(`${API_URL}/user/forms`, () => jotformResponse(createForm())),
+  http.put(`${API_URL}/user/forms`, () => jotformResponse(createForm())),
+  http.get(`${API_URL}/form/:formId`, ({ params }) =>
+    jotformResponse(forms.get(String(params.formId)) ?? { id: params.formId }),
+  ),
+  http.delete(`${API_URL}/form/:formId`, ({ params }) => {
+    const id = String(params.formId);
+
+    forms.delete(id);
+
+    return jotformResponse({ id });
+  }),
+  http.post(`${API_URL}/form/:formId/clone`, () => jotformResponse(createForm())),
+  http.get(`${API_URL}/form/:formId/files`, () => jotformResponse([])),
+
+  http.get(`${API_URL}/form/:formId/properties`, ({ params }) =>
+    jotformResponse(getOrCreateProperties(String(params.formId))),
+  ),
+  http.get(`${API_URL}/form/:formId/properties/:key`, ({ params }) => {
+    const properties = getOrCreateProperties(String(params.formId));
+    const key = String(params.key);
+
+    return jotformResponse({ [key]: properties[key] ?? 'Test form' });
+  }),
+  http.post(`${API_URL}/form/:formId/properties`, async ({ params, request }) => {
+    const properties = getOrCreateProperties(String(params.formId));
+    const body = await getFormData(request);
+    const pagetitle = body['properties[pagetitle]'];
+
+    if (pagetitle !== undefined) {
+      properties.pagetitle = pagetitle;
+    }
+
+    return jotformResponse({ ...properties, formID: params.formId });
+  }),
+  http.put(`${API_URL}/form/:formId/properties`, async ({ params, request }) => {
+    const properties = getOrCreateProperties(String(params.formId));
+    const body = (await request.json()) as { properties?: Record<string, unknown> };
+
+    Object.assign(properties, body.properties);
+
+    return jotformResponse({ ...properties, formID: params.formId });
+  }),
+
+  http.get(`${API_URL}/form/:formId/questions`, () =>
+    jotformResponse(Object.fromEntries(questions)),
+  ),
+  http.post(`${API_URL}/form/:formId/questions`, async ({ request }) => {
+    const body = await getFormData(request);
+    const question = Object.fromEntries(
+      Object.entries(body)
+        .filter(([key]) => key.startsWith('question['))
+        .map(([key, value]) => [key.slice(9, -1), value]),
+    );
+
+    return jotformResponse(createQuestion(question));
+  }),
+  http.put(`${API_URL}/form/:formId/questions`, async ({ request }) => {
+    const body = (await request.json()) as { questions?: Record<string, unknown>[] };
+
+    return jotformResponse((body.questions ?? []).map((question) => createQuestion(question)));
+  }),
+  http.get(`${API_URL}/form/:formId/question/:questionId`, ({ params }) =>
+    jotformResponse(questions.get(String(params.questionId)) ?? {}),
+  ),
+  http.post(`${API_URL}/form/:formId/question/:questionId`, async ({ params, request }) => {
+    const id = String(params.questionId);
+    const body = await getFormData(request);
+    const updates = Object.fromEntries(
+      Object.entries(body)
+        .filter(([key]) => key.startsWith('question['))
+        .map(([key, value]) => [key.slice(9, -1), value]),
+    );
+    const question = { ...(questions.get(id) ?? {}), ...updates };
+
+    questions.set(id, question);
+
+    return jotformResponse([question]);
+  }),
+  http.delete(`${API_URL}/form/:formId/question/:questionId`, ({ params }) => {
+    const id = String(params.questionId);
+
+    questions.delete(id);
+
+    return jotformResponse(`QuestionID #${id} successfully deleted.`);
+  }),
+
+  http.get(`${API_URL}/form/:formId/reports`, () => jotformResponse(Array.from(reports.values()))),
+  http.post(`${API_URL}/form/:formId/reports`, () => jotformResponse(createReport())),
+  http.get(`${API_URL}/user/reports`, () => jotformResponse(Array.from(reports.values()))),
+  http.get(`${API_URL}/report/:reportId`, () =>
+    jotformError("You're not authorized to use (/report-id)"),
+  ),
+  http.delete(`${API_URL}/report/:reportId`, ({ params }) => {
+    reports.delete(String(params.reportId));
+
+    return jotformResponse(true);
+  }),
+
+  http.get(`${API_URL}/form/:formId/submissions`, () =>
+    jotformResponse(Array.from(submissions.values())),
+  ),
+  http.post(`${API_URL}/form/:formId/submissions`, () => jotformResponse(createSubmission())),
+  http.put(`${API_URL}/form/:formId/submissions`, async ({ request }) => {
+    const body = await request.json();
+    const count = Array.isArray(body) ? body.length : 1;
+
+    return jotformResponse(Array.from({ length: count }, () => createSubmission()));
+  }),
+  http.get(`${API_URL}/user/submissions`, () => jotformResponse(Array.from(submissions.values()))),
+  http.get(`${API_URL}/submission/:submissionId`, ({ params }) =>
+    jotformResponse(
+      submissions.get(String(params.submissionId)) ?? {
+        id: params.submissionId,
+        form_id: TEST_FORM_ID,
+      },
+    ),
+  ),
+  http.post(`${API_URL}/submission/:submissionId`, async ({ params, request }) => {
+    const id = String(params.submissionId);
+    const body = await getFormData(request);
+    const submission = { ...(submissions.get(id) ?? { id }), ...body };
+
+    submissions.set(id, submission);
+
+    return jotformResponse(submission);
+  }),
+  http.delete(`${API_URL}/submission/:submissionId`, ({ params }) => {
+    const id = String(params.submissionId);
+
+    submissions.delete(id);
+
+    return jotformResponse(`Submission #${id} deleted successfully.`);
+  }),
+
+  http.get(`${API_URL}/form/:formId/webhooks`, () => jotformResponse(Object.fromEntries(webhooks))),
+  http.post(`${API_URL}/form/:formId/webhooks`, async ({ request }) => {
+    const body = await getFormData(request);
+    const id = String(webhookSequence);
+
+    webhookSequence += 1;
+    webhooks.set(id, body.webhookURL ?? 'https://example.com/webhook');
+
+    return jotformResponse(Object.fromEntries(webhooks));
+  }),
+  http.delete(`${API_URL}/form/:formId/webhooks/:webhookId`, ({ params }) => {
+    webhooks.delete(String(params.webhookId));
+
+    return jotformResponse({});
+  }),
+
+  http.get(`${API_URL}/user/labels`, () =>
+    jotformResponse({
+      id: TEST_ROOT_LABEL_ID,
+      sublabels: [
+        {
+          id: TEST_LABEL_ID,
+          sublabels: [
+            {
+              id: TEST_SUBLABEL_ID,
+              sublabels: [],
+            },
+          ],
+        },
+      ],
+    }),
+  ),
+  http.post(`${API_URL}/label`, async ({ request }) => {
+    labelSequence += 1;
+
+    const body = await getFormData(request);
+    const label = {
+      id: `created-label-${labelSequence}`,
+      name: body.name,
+      color: body.color,
+      resources: [],
+    };
+
+    labels.set(label.id, label);
+
+    return jotformResponse(label);
+  }),
+  http.get(`${API_URL}/label/:labelId`, ({ params }) =>
+    jotformResponse(labels.get(String(params.labelId)) ?? { id: params.labelId }),
+  ),
+  http.put(`${API_URL}/label/:labelId`, async ({ params, request }) => {
+    const id = String(params.labelId);
+    const label = {
+      ...(labels.get(id) ?? { id, resources: [] }),
+      ...((await request.json()) as Record<string, unknown>),
+    };
+
+    labels.set(id, label);
+
+    return jotformResponse(label);
+  }),
+  http.get(`${API_URL}/label/:labelId/resources`, ({ params }) => {
+    const label = labels.get(String(params.labelId));
+
+    return jotformResponse(label?.resources ?? []);
+  }),
+  http.put(`${API_URL}/label/:labelId/add-resources`, async ({ params, request }) => {
+    const id = String(params.labelId);
+    const body = (await request.json()) as { resources: unknown[] };
+    const label = labels.get(id) ?? { id };
+
+    labels.set(id, { ...label, resources: body.resources });
+
+    return jotformResponse(body.resources);
+  }),
+  http.put(`${API_URL}/label/:labelId/remove-resources`, async ({ params, request }) => {
+    const id = String(params.labelId);
+    const body = (await request.json()) as { resources: unknown[] };
+    const label = labels.get(id) ?? { id };
+
+    labels.set(id, { ...label, resources: [] });
+
+    return jotformResponse(body.resources);
+  }),
+  http.delete(`${API_URL}/label/:labelId`, ({ params }) => {
+    labels.delete(String(params.labelId));
+
+    return jotformResponse(true);
+  }),
+);

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,12 +1,17 @@
+import { afterAll, beforeAll } from 'vitest';
+
 import * as jotform from './src/index.js';
+import { API_URL, server } from './test/mockServer.js';
 
-const JOTFORM_API_KEY = process.env.JOTFORM_API_KEY;
+beforeAll(() => {
+  server.listen({ onUnhandledRequest: 'error' });
+});
 
-if (!JOTFORM_API_KEY) {
-  throw new Error('JOTFORM_API_KEY is undefined');
-}
+afterAll(() => {
+  server.close();
+});
 
 jotform.options({
-  apiKey: JOTFORM_API_KEY,
-  debug: true,
+  apiKey: 'test-api-key',
+  url: API_URL,
 });

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -9,4 +9,5 @@ if (!JOTFORM_API_KEY) {
 jotform.options({
   apiKey: JOTFORM_API_KEY,
   debug: true,
+  timeout: 30_000,
 });

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -9,5 +9,4 @@ if (!JOTFORM_API_KEY) {
 jotform.options({
   apiKey: JOTFORM_API_KEY,
   debug: true,
-  timeout: 30_000,
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -124,10 +124,85 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@inquirer/ansi@npm:^2.0.7":
+  version: 2.0.7
+  resolution: "@inquirer/ansi@npm:2.0.7"
+  checksum: 10c0/a574f97a899f0d9346fa26b528b3f4a9ba6dcb9172288efb6b4314d8486470ed53d2f538200f66a25b843c6e0cbf83688c6d5174a8dc6eca853b291b09609c5a
+  languageName: node
+  linkType: hard
+
+"@inquirer/confirm@npm:^6.0.11":
+  version: 6.1.1
+  resolution: "@inquirer/confirm@npm:6.1.1"
+  dependencies:
+    "@inquirer/core": "npm:^11.2.1"
+    "@inquirer/type": "npm:^4.0.7"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10c0/4684406161c09327df830b4026f3165b31e13831276d215051586408ed434423263b15686393ce95a4b55058c1b7f9b08aa4b66f5ac930b47523fff75051d36f
+  languageName: node
+  linkType: hard
+
+"@inquirer/core@npm:^11.2.1":
+  version: 11.2.1
+  resolution: "@inquirer/core@npm:11.2.1"
+  dependencies:
+    "@inquirer/ansi": "npm:^2.0.7"
+    "@inquirer/figures": "npm:^2.0.7"
+    "@inquirer/type": "npm:^4.0.7"
+    cli-width: "npm:^4.1.0"
+    fast-wrap-ansi: "npm:^0.2.0"
+    mute-stream: "npm:^3.0.0"
+    signal-exit: "npm:^4.1.0"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10c0/b5be386cecd9e441ac2f9d3417a6ae1c4658b3ee6cdf5dae791211400f4de158851f81fca2245e2062833716f95366b9e1717770828cb7365e756c16e822f0d2
+  languageName: node
+  linkType: hard
+
+"@inquirer/figures@npm:^2.0.7":
+  version: 2.0.7
+  resolution: "@inquirer/figures@npm:2.0.7"
+  checksum: 10c0/e0573dc9ad25fa3628d5164745e52852d8cd832a9918605b7716df2e37a0005a0aaf40b6d81cef2ca09cb708b200e61b82d1dcd17003f572577e233c19a9ec7b
+  languageName: node
+  linkType: hard
+
+"@inquirer/type@npm:^4.0.7":
+  version: 4.0.7
+  resolution: "@inquirer/type@npm:4.0.7"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10c0/80678ac1c6e19ce309909e4a54a69adc95697ea3abc2cb92f17b1bc52f4caadbcb4003ae7339fb5a70c0d36d3bde975e1bb4450069662f41c953a0d28695bb70
+  languageName: node
+  linkType: hard
+
 "@jridgewell/sourcemap-codec@npm:^1.5.5":
   version: 1.5.5
   resolution: "@jridgewell/sourcemap-codec@npm:1.5.5"
   checksum: 10c0/f9e538f302b63c0ebc06eecb1dd9918dd4289ed36147a0ddce35d6ea4d7ebbda243cda7b2213b6a5e1d8087a298d5cf630fb2bd39329cdecb82017023f6081a0
+  languageName: node
+  linkType: hard
+
+"@mswjs/interceptors@npm:^0.41.3":
+  version: 0.41.9
+  resolution: "@mswjs/interceptors@npm:0.41.9"
+  dependencies:
+    "@open-draft/deferred-promise": "npm:^2.2.0"
+    "@open-draft/logger": "npm:^0.3.0"
+    "@open-draft/until": "npm:^2.0.0"
+    is-node-process: "npm:^1.2.0"
+    outvariant: "npm:^1.4.3"
+    strict-event-emitter: "npm:^0.5.1"
+  checksum: 10c0/2efff40877e07ce29846be76c2683177308a72a3ccfe4c096b496412a279acd92b5b9cdad40ad71c36b149a4a7d9e9b4e7d295893a8ba9661b43334f5784ecd8
   languageName: node
   linkType: hard
 
@@ -140,6 +215,37 @@ __metadata:
     "@emnapi/core": ^1.7.1
     "@emnapi/runtime": ^1.7.1
   checksum: 10c0/2e88e1955258949ccf2d18c79975821ad38071b465ef126a5e14110977b97868867b016c1ad046e963cccc42c0bd9db6c8ff5fd1ebb61b87bb3487f339041658
+  languageName: node
+  linkType: hard
+
+"@open-draft/deferred-promise@npm:^2.2.0":
+  version: 2.2.0
+  resolution: "@open-draft/deferred-promise@npm:2.2.0"
+  checksum: 10c0/eafc1b1d0fc8edb5e1c753c5e0f3293410b40dde2f92688211a54806d4136887051f39b98c1950370be258483deac9dfd17cf8b96557553765198ef2547e4549
+  languageName: node
+  linkType: hard
+
+"@open-draft/deferred-promise@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@open-draft/deferred-promise@npm:3.0.0"
+  checksum: 10c0/4dd697e55495e436be9536413cc9975e792e9ca7472e81e3d3d69e9b65cb678465aac90b463ac02f2b490c0581c4e9aa8a33d2a5857decbe2c6d9ffb310f8e1f
+  languageName: node
+  linkType: hard
+
+"@open-draft/logger@npm:^0.3.0":
+  version: 0.3.0
+  resolution: "@open-draft/logger@npm:0.3.0"
+  dependencies:
+    is-node-process: "npm:^1.2.0"
+    outvariant: "npm:^1.4.0"
+  checksum: 10c0/90010647b22e9693c16258f4f9adb034824d1771d3baa313057b9a37797f571181005bc50415a934eaf7c891d90ff71dcd7a9d5048b0b6bb438f31bef2c7c5c1
+  languageName: node
+  linkType: hard
+
+"@open-draft/until@npm:^2.0.0":
+  version: 2.1.0
+  resolution: "@open-draft/until@npm:2.1.0"
+  checksum: 10c0/61d3f99718dd86bb393fee2d7a785f961dcaf12f2055f0c693b27f4d0cd5f7a03d498a6d9289773b117590d794a43cd129366fd8e99222e4832f67b1653d54cf
   languageName: node
   linkType: hard
 
@@ -311,6 +417,22 @@ __metadata:
   dependencies:
     undici-types: "npm:~6.21.0"
   checksum: 10c0/ee040c29c891aa37fffc27d04a8529318c391356346933646b7692eaf62236831ad532f6ebaf43ebd6a2ef1f0f091860d8a0a83a4e3c5a4f66d37aa1b2c99f31
+  languageName: node
+  linkType: hard
+
+"@types/set-cookie-parser@npm:^2.4.10":
+  version: 2.4.10
+  resolution: "@types/set-cookie-parser@npm:2.4.10"
+  dependencies:
+    "@types/node": "npm:*"
+  checksum: 10c0/010b0c582ea70a2088618b4725808e80c30cce296c19ec58e51d94e0fd1038201b7b99238bf3ea74e1894163c8037d10a4f1729de62b2801ce240ff070f43e76
+  languageName: node
+  linkType: hard
+
+"@types/statuses@npm:^2.0.6":
+  version: 2.0.6
+  resolution: "@types/statuses@npm:2.0.6"
+  checksum: 10c0/dd88c220b0e2c6315686289525fd61472d2204d2e4bef4941acfb76bda01d3066f749ac74782aab5b537a45314fcd7d6261eefa40b6ec872691f5803adaa608d
   languageName: node
   linkType: hard
 
@@ -551,6 +673,7 @@ __metadata:
     "@types/node": "npm:*"
     "@wojtekmaj/async-array-utils": "npm:^2.0.0"
     husky: "npm:^9.0.0"
+    msw: "npm:^2.15.0"
     object-to-formdata: "npm:^4.5.1"
     p-throttle: "npm:^7.0.0"
     typescript: "npm:^7.0.2"
@@ -559,10 +682,60 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"ansi-regex@npm:^5.0.1":
+  version: 5.0.1
+  resolution: "ansi-regex@npm:5.0.1"
+  checksum: 10c0/9a64bb8627b434ba9327b60c027742e5d17ac69277960d041898596271d992d4d52ba7267a63ca10232e29f6107fc8a835f6ce8d719b88c5f8493f8254813737
+  languageName: node
+  linkType: hard
+
+"ansi-styles@npm:^4.0.0":
+  version: 4.3.0
+  resolution: "ansi-styles@npm:4.3.0"
+  dependencies:
+    color-convert: "npm:^2.0.1"
+  checksum: 10c0/895a23929da416f2bd3de7e9cb4eabd340949328ab85ddd6e484a637d8f6820d485f53933446f5291c3b760cbc488beb8e88573dd0f9c7daf83dccc8fe81b041
+  languageName: node
+  linkType: hard
+
 "chai@npm:^6.2.2":
   version: 6.2.2
   resolution: "chai@npm:6.2.2"
   checksum: 10c0/e6c69e5f0c11dffe6ea13d0290936ebb68fcc1ad688b8e952e131df6a6d5797d5e860bc55cef1aca2e950c3e1f96daf79e9d5a70fb7dbaab4e46355e2635ed53
+  languageName: node
+  linkType: hard
+
+"cli-width@npm:^4.1.0":
+  version: 4.1.0
+  resolution: "cli-width@npm:4.1.0"
+  checksum: 10c0/1fbd56413578f6117abcaf858903ba1f4ad78370a4032f916745fa2c7e390183a9d9029cf837df320b0fdce8137668e522f60a30a5f3d6529ff3872d265a955f
+  languageName: node
+  linkType: hard
+
+"cliui@npm:^8.0.1":
+  version: 8.0.1
+  resolution: "cliui@npm:8.0.1"
+  dependencies:
+    string-width: "npm:^4.2.0"
+    strip-ansi: "npm:^6.0.1"
+    wrap-ansi: "npm:^7.0.0"
+  checksum: 10c0/4bda0f09c340cbb6dfdc1ed508b3ca080f12992c18d68c6be4d9cf51756033d5266e61ec57529e610dacbf4da1c634423b0c1b11037709cc6b09045cbd815df5
+  languageName: node
+  linkType: hard
+
+"color-convert@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "color-convert@npm:2.0.1"
+  dependencies:
+    color-name: "npm:~1.1.4"
+  checksum: 10c0/37e1150172f2e311fe1b2df62c6293a342ee7380da7b9cfdba67ea539909afbd74da27033208d01d6d5cfc65ee7868a22e18d7e7648e004425441c0f8a15a7d7
+  languageName: node
+  linkType: hard
+
+"color-name@npm:~1.1.4":
+  version: 1.1.4
+  resolution: "color-name@npm:1.1.4"
+  checksum: 10c0/a1a3f914156960902f46f7f56bc62effc6c94e84b2cae157a526b1c1f74b677a47ec602bf68a61abfa2b42d15b7c5651c6dbe72a43af720bc588dff885b10f95
   languageName: node
   linkType: hard
 
@@ -573,6 +746,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"cookie@npm:^1.1.1":
+  version: 1.1.1
+  resolution: "cookie@npm:1.1.1"
+  checksum: 10c0/79c4ddc0fcad9c4f045f826f42edf54bcc921a29586a4558b0898277fa89fb47be95bc384c2253f493af7b29500c830da28341274527328f18eba9f58afa112c
+  languageName: node
+  linkType: hard
+
 "detect-libc@npm:^2.0.3":
   version: 2.1.2
   resolution: "detect-libc@npm:2.1.2"
@@ -580,10 +760,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"emoji-regex@npm:^8.0.0":
+  version: 8.0.0
+  resolution: "emoji-regex@npm:8.0.0"
+  checksum: 10c0/b6053ad39951c4cf338f9092d7bfba448cdfd46fe6a2a034700b149ac9ffbc137e361cbd3c442297f86bed2e5f7576c1b54cc0a6bf8ef5106cc62f496af35010
+  languageName: node
+  linkType: hard
+
 "es-module-lexer@npm:^2.0.0":
   version: 2.0.0
   resolution: "es-module-lexer@npm:2.0.0"
   checksum: 10c0/ae78dbbd43035a4b972c46cfb6877e374ea290adfc62bc2f5a083fea242c0b2baaab25c5886af86be55f092f4a326741cb94334cd3c478c383fdc8a9ec5ff817
+  languageName: node
+  linkType: hard
+
+"escalade@npm:^3.1.1":
+  version: 3.2.0
+  resolution: "escalade@npm:3.2.0"
+  checksum: 10c0/ced4dd3a78e15897ed3be74e635110bbf3b08877b0a41be50dcb325ee0e0b5f65fc2d50e9845194d7c4633f327e2e1c6cce00a71b617c5673df0374201d67f65
   languageName: node
   linkType: hard
 
@@ -600,6 +794,31 @@ __metadata:
   version: 1.3.0
   resolution: "expect-type@npm:1.3.0"
   checksum: 10c0/8412b3fe4f392c420ab41dae220b09700e4e47c639a29ba7ba2e83cc6cffd2b4926f7ac9e47d7e277e8f4f02acda76fd6931cb81fd2b382fa9477ef9ada953fd
+  languageName: node
+  linkType: hard
+
+"fast-string-truncated-width@npm:^3.0.2":
+  version: 3.0.3
+  resolution: "fast-string-truncated-width@npm:3.0.3"
+  checksum: 10c0/043b8663397d14a3880ce4f3407bcda60b40db9bbeafe62863a35d1f9c69ea17c8da3fcd72de235553e6c9cd053128cde9e24ca0d4a7463208f48db3cd23d981
+  languageName: node
+  linkType: hard
+
+"fast-string-width@npm:^3.0.2":
+  version: 3.0.2
+  resolution: "fast-string-width@npm:3.0.2"
+  dependencies:
+    fast-string-truncated-width: "npm:^3.0.2"
+  checksum: 10c0/c8822d175315bb353ebe782b65214ac53b13e3bf704e03b132ea7bdfa8de6a636375b3ab7a4097545393d109381c37c4f387c72a462c90b61412dbc4632f39a7
+  languageName: node
+  linkType: hard
+
+"fast-wrap-ansi@npm:^0.2.0":
+  version: 0.2.2
+  resolution: "fast-wrap-ansi@npm:0.2.2"
+  dependencies:
+    fast-string-width: "npm:^3.0.2"
+  checksum: 10c0/1aa7be4f7cb86f4bdb14691cb6bcc0b8df8b3b89df142ade3ae1602332dcf6f990cd750a923cd581ca0847808cb4ec1aa5afaafa7a72f849e87a2a62c98fa370
   languageName: node
   linkType: hard
 
@@ -630,12 +849,50 @@ __metadata:
   languageName: node
   linkType: hard
 
+"get-caller-file@npm:^2.0.5":
+  version: 2.0.5
+  resolution: "get-caller-file@npm:2.0.5"
+  checksum: 10c0/c6c7b60271931fa752aeb92f2b47e355eac1af3a2673f47c9589e8f8a41adc74d45551c1bc57b5e66a80609f10ffb72b6f575e4370d61cc3f7f3aaff01757cde
+  languageName: node
+  linkType: hard
+
+"graphql@npm:^16.13.2":
+  version: 16.14.2
+  resolution: "graphql@npm:16.14.2"
+  checksum: 10c0/a95a96961eaff55cc9fe9d31fae6f33499ac988b972d07ea5085024cb1333f515b902f376e7393a5489aa82200a8aff3eb96580e4d1b69d702ed19b6eb1ce97a
+  languageName: node
+  linkType: hard
+
+"headers-polyfill@npm:^5.0.1":
+  version: 5.0.1
+  resolution: "headers-polyfill@npm:5.0.1"
+  dependencies:
+    "@types/set-cookie-parser": "npm:^2.4.10"
+    set-cookie-parser: "npm:^3.0.1"
+  checksum: 10c0/c269730a88a12c88718037aa71f178601f2b193ba8a37e276b6ced6b8f7e06fc1ac051f2a7acb0a8b4cc878407066555fdcdbb270e90374baaa472cb26af0c30
+  languageName: node
+  linkType: hard
+
 "husky@npm:^9.0.0":
   version: 9.0.7
   resolution: "husky@npm:9.0.7"
   bin:
     husky: bin.js
   checksum: 10c0/ac36838bc230b42ca878eeb6993cba5499b858700581fa9e8b579227af9ad47bdbf4c050f4145f51f33f77c16d359f329622b7050150c78a7c52be26cc24174e
+  languageName: node
+  linkType: hard
+
+"is-fullwidth-code-point@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "is-fullwidth-code-point@npm:3.0.0"
+  checksum: 10c0/bb11d825e049f38e04c06373a8d72782eee0205bda9d908cc550ccb3c59b99d750ff9537982e01733c1c94a58e35400661f57042158ff5e8f3e90cf936daf0fc
+  languageName: node
+  linkType: hard
+
+"is-node-process@npm:^1.2.0":
+  version: 1.2.0
+  resolution: "is-node-process@npm:1.2.0"
+  checksum: 10c0/5b24fda6776d00e42431d7bcd86bce81cb0b6cabeb944142fe7b077a54ada2e155066ad06dbe790abdb397884bdc3151e04a9707b8cd185099efbc79780573ed
   languageName: node
   linkType: hard
 
@@ -768,6 +1025,46 @@ __metadata:
   languageName: node
   linkType: hard
 
+"msw@npm:^2.15.0":
+  version: 2.15.0
+  resolution: "msw@npm:2.15.0"
+  dependencies:
+    "@inquirer/confirm": "npm:^6.0.11"
+    "@mswjs/interceptors": "npm:^0.41.3"
+    "@open-draft/deferred-promise": "npm:^3.0.0"
+    "@types/statuses": "npm:^2.0.6"
+    cookie: "npm:^1.1.1"
+    graphql: "npm:^16.13.2"
+    headers-polyfill: "npm:^5.0.1"
+    is-node-process: "npm:^1.2.0"
+    outvariant: "npm:^1.4.3"
+    path-to-regexp: "npm:^6.3.0"
+    picocolors: "npm:^1.1.1"
+    rettime: "npm:^0.11.11"
+    statuses: "npm:^2.0.2"
+    strict-event-emitter: "npm:^0.5.1"
+    tough-cookie: "npm:^6.0.1"
+    type-fest: "npm:^5.5.0"
+    until-async: "npm:^3.0.2"
+    yargs: "npm:^17.7.2"
+  peerDependencies:
+    typescript: ">= 4.8.x"
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  bin:
+    msw: cli/index.js
+  checksum: 10c0/0d3dbf1b062a82b3711ff195e10ffd9e6f2a5e337b4a0f08cabdb8d0b96c5c0c057f1cdcb67da14c356612554ea463fb5ad8f9c618b5ac009fc4eee43a83c94e
+  languageName: node
+  linkType: hard
+
+"mute-stream@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "mute-stream@npm:3.0.0"
+  checksum: 10c0/12cdb36a101694c7a6b296632e6d93a30b74401873cf7507c88861441a090c71c77a58f213acadad03bc0c8fa186639dec99d68a14497773a8744320c136e701
+  languageName: node
+  linkType: hard
+
 "nanoid@npm:^3.3.12":
   version: 3.3.12
   resolution: "nanoid@npm:3.3.12"
@@ -791,10 +1088,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"outvariant@npm:^1.4.0, outvariant@npm:^1.4.3":
+  version: 1.4.3
+  resolution: "outvariant@npm:1.4.3"
+  checksum: 10c0/5976ca7740349cb8c71bd3382e2a762b1aeca6f33dc984d9d896acdf3c61f78c3afcf1bfe9cc633a7b3c4b295ec94d292048f83ea2b2594fae4496656eba992c
+  languageName: node
+  linkType: hard
+
 "p-throttle@npm:^7.0.0":
   version: 7.0.0
   resolution: "p-throttle@npm:7.0.0"
   checksum: 10c0/7a9ca80826808b3d7f946369fc17a0ba020064c1bda9a5dfa74d2c9713f896576cdc4872bd61091ef2950d6a84072cac672bb1eb88a8b6a0c9e348d030623fc1
+  languageName: node
+  linkType: hard
+
+"path-to-regexp@npm:^6.3.0":
+  version: 6.3.0
+  resolution: "path-to-regexp@npm:6.3.0"
+  checksum: 10c0/73b67f4638b41cde56254e6354e46ae3a2ebc08279583f6af3d96fe4664fc75788f74ed0d18ca44fa4a98491b69434f9eee73b97bb5314bd1b5adb700f5c18d6
   languageName: node
   linkType: hard
 
@@ -827,6 +1138,20 @@ __metadata:
     picocolors: "npm:^1.1.1"
     source-map-js: "npm:^1.2.1"
   checksum: 10c0/7f2e63ae22fbe43aace1bf652bd99da4e90737c64194d49e51ddc9cd0f9e51ff2861a7d734379b494deffa03a880a5c65eec70bc29ee9ebaa7136dde3eee8f31
+  languageName: node
+  linkType: hard
+
+"require-directory@npm:^2.1.1":
+  version: 2.1.1
+  resolution: "require-directory@npm:2.1.1"
+  checksum: 10c0/83aa76a7bc1531f68d92c75a2ca2f54f1b01463cb566cf3fbc787d0de8be30c9dbc211d1d46be3497dac5785fe296f2dd11d531945ac29730643357978966e99
+  languageName: node
+  linkType: hard
+
+"rettime@npm:^0.11.11":
+  version: 0.11.11
+  resolution: "rettime@npm:0.11.11"
+  checksum: 10c0/021fc9d9870ce04f032952e63fc5576f3f8e7c9c15513b1a479a64646df90239802eef6d60a98cbfb6ac87bb623d4f120a8ee71193d02984e3d2915c28695f6e
   languageName: node
   linkType: hard
 
@@ -888,10 +1213,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"set-cookie-parser@npm:^3.0.1":
+  version: 3.1.2
+  resolution: "set-cookie-parser@npm:3.1.2"
+  checksum: 10c0/ea3d4fba5affd57f2a4c2e5172d701c4c17645879f9fddf1331622ae556210d840cdcb6666f0d71288ad545e31db5927bf49696051928e0186e079588cd5ddb0
+  languageName: node
+  linkType: hard
+
 "siginfo@npm:^2.0.0":
   version: 2.0.0
   resolution: "siginfo@npm:2.0.0"
   checksum: 10c0/3def8f8e516fbb34cb6ae415b07ccc5d9c018d85b4b8611e3dc6f8be6d1899f693a4382913c9ed51a06babb5201639d76453ab297d1c54a456544acf5c892e34
+  languageName: node
+  linkType: hard
+
+"signal-exit@npm:^4.1.0":
+  version: 4.1.0
+  resolution: "signal-exit@npm:4.1.0"
+  checksum: 10c0/41602dce540e46d599edba9d9860193398d135f7ff72cab629db5171516cfae628d21e7bfccde1bbfdf11c48726bc2a6d1a8fb8701125852fbfda7cf19c6aa83
   languageName: node
   linkType: hard
 
@@ -909,10 +1248,51 @@ __metadata:
   languageName: node
   linkType: hard
 
+"statuses@npm:^2.0.2":
+  version: 2.0.2
+  resolution: "statuses@npm:2.0.2"
+  checksum: 10c0/a9947d98ad60d01f6b26727570f3bcceb6c8fa789da64fe6889908fe2e294d57503b14bf2b5af7605c2d36647259e856635cd4c49eab41667658ec9d0080ec3f
+  languageName: node
+  linkType: hard
+
 "std-env@npm:^4.0.0-rc.1":
   version: 4.0.0
   resolution: "std-env@npm:4.0.0"
   checksum: 10c0/63b1716eae27947adde49e21b7225a0f75fb2c3d410273ae9de8333c07c7d5fc7a0628ae4c8af6b4b49b4274ed46c2bf118ed69b64f1261c9d8213d76ed1c16c
+  languageName: node
+  linkType: hard
+
+"strict-event-emitter@npm:^0.5.1":
+  version: 0.5.1
+  resolution: "strict-event-emitter@npm:0.5.1"
+  checksum: 10c0/f5228a6e6b6393c57f52f62e673cfe3be3294b35d6f7842fc24b172ae0a6e6c209fa83241d0e433fc267c503bc2f4ffdbe41a9990ff8ffd5ac425ec0489417f7
+  languageName: node
+  linkType: hard
+
+"string-width@npm:^4.1.0, string-width@npm:^4.2.0, string-width@npm:^4.2.3":
+  version: 4.2.3
+  resolution: "string-width@npm:4.2.3"
+  dependencies:
+    emoji-regex: "npm:^8.0.0"
+    is-fullwidth-code-point: "npm:^3.0.0"
+    strip-ansi: "npm:^6.0.1"
+  checksum: 10c0/1e525e92e5eae0afd7454086eed9c818ee84374bb80328fc41217ae72ff5f065ef1c9d7f72da41de40c75fa8bb3dee63d92373fd492c84260a552c636392a47b
+  languageName: node
+  linkType: hard
+
+"strip-ansi@npm:^6.0.0, strip-ansi@npm:^6.0.1":
+  version: 6.0.1
+  resolution: "strip-ansi@npm:6.0.1"
+  dependencies:
+    ansi-regex: "npm:^5.0.1"
+  checksum: 10c0/1ae5f212a126fe5b167707f716942490e3933085a5ff6c008ab97ab2f272c8025d3aa218b7bd6ab25729ca20cc81cddb252102f8751e13482a5199e873680952
+  languageName: node
+  linkType: hard
+
+"tagged-tag@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "tagged-tag@npm:1.0.0"
+  checksum: 10c0/91d25c9ffb86a91f20522cefb2cbec9b64caa1febe27ad0df52f08993ff60888022d771e868e6416cf2e72dab68449d2139e8709ba009b74c6c7ecd4000048d1
   languageName: node
   linkType: hard
 
@@ -947,10 +1327,46 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tldts-core@npm:^7.4.8":
+  version: 7.4.8
+  resolution: "tldts-core@npm:7.4.8"
+  checksum: 10c0/94edee2a06cb1929fae4a26045628b01dd865ee8e28661df29128228522fb8dcf29c2f68ffa7286ee41a2a2c98da3e6814dbf49a1f6509de3fe2c9448e0db1b7
+  languageName: node
+  linkType: hard
+
+"tldts@npm:^7.0.5":
+  version: 7.4.8
+  resolution: "tldts@npm:7.4.8"
+  dependencies:
+    tldts-core: "npm:^7.4.8"
+  bin:
+    tldts: bin/cli.js
+  checksum: 10c0/438b379a43b105359311427b8ab9d73572244996b4f6dd1fbe9112bd274c308d4ffb33b6f644302e79c8bc60f2e2539463b00dd91ee1063b92d9fc8b10882b6c
+  languageName: node
+  linkType: hard
+
+"tough-cookie@npm:^6.0.1":
+  version: 6.0.2
+  resolution: "tough-cookie@npm:6.0.2"
+  dependencies:
+    tldts: "npm:^7.0.5"
+  checksum: 10c0/5ff521a476a3c540821352125a5d481c8d2fe16035de7e0efda4df120f290c95500a0e9b51ea0aa56343955be482e014c30f5ba73e04b93ba138e4e855cb9e89
+  languageName: node
+  linkType: hard
+
 "tslib@npm:^2.4.0":
   version: 2.8.1
   resolution: "tslib@npm:2.8.1"
   checksum: 10c0/9c4759110a19c53f992d9aae23aac5ced636e99887b51b9e61def52611732872ff7668757d4e4c61f19691e36f4da981cd9485e869b4a7408d689f6bf1f14e62
+  languageName: node
+  linkType: hard
+
+"type-fest@npm:^5.5.0":
+  version: 5.8.0
+  resolution: "type-fest@npm:5.8.0"
+  dependencies:
+    tagged-tag: "npm:^1.0.0"
+  checksum: 10c0/c8aae118a763d550a9552a511dff6b71840a23dab4edf693cf1c4df22596942794e6f6723389bd9036a90182249d915158bacf0815a1ae87f05f901b1d5f574e
   languageName: node
   linkType: hard
 
@@ -1103,6 +1519,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"until-async@npm:^3.0.2":
+  version: 3.0.2
+  resolution: "until-async@npm:3.0.2"
+  checksum: 10c0/61c8b03895dbe18fe3d90316d0a1894e0c131ea4b1673f6ce78eed993d0bb81bbf4b7adf8477e9ff7725782a76767eed9d077561cfc9f89b4a1ebe61f7c9828e
+  languageName: node
+  linkType: hard
+
 "vite@npm:^6.0.0 || ^7.0.0 || ^8.0.0":
   version: 8.0.16
   resolution: "vite@npm:8.0.16"
@@ -1237,6 +1660,46 @@ __metadata:
   bin:
     why-is-node-running: cli.js
   checksum: 10c0/1cde0b01b827d2cf4cb11db962f3958b9175d5d9e7ac7361d1a7b0e2dc6069a263e69118bd974c4f6d0a890ef4eedfe34cf3d5167ec14203dbc9a18620537054
+  languageName: node
+  linkType: hard
+
+"wrap-ansi@npm:^7.0.0":
+  version: 7.0.0
+  resolution: "wrap-ansi@npm:7.0.0"
+  dependencies:
+    ansi-styles: "npm:^4.0.0"
+    string-width: "npm:^4.1.0"
+    strip-ansi: "npm:^6.0.0"
+  checksum: 10c0/d15fc12c11e4cbc4044a552129ebc75ee3f57aa9c1958373a4db0292d72282f54373b536103987a4a7594db1ef6a4f10acf92978f79b98c49306a4b58c77d4da
+  languageName: node
+  linkType: hard
+
+"y18n@npm:^5.0.5":
+  version: 5.0.8
+  resolution: "y18n@npm:5.0.8"
+  checksum: 10c0/4df2842c36e468590c3691c894bc9cdbac41f520566e76e24f59401ba7d8b4811eb1e34524d57e54bc6d864bcb66baab7ffd9ca42bf1eda596618f9162b91249
+  languageName: node
+  linkType: hard
+
+"yargs-parser@npm:^21.1.1":
+  version: 21.1.1
+  resolution: "yargs-parser@npm:21.1.1"
+  checksum: 10c0/f84b5e48169479d2f402239c59f084cfd1c3acc197a05c59b98bab067452e6b3ea46d4dd8ba2985ba7b3d32a343d77df0debd6b343e5dae3da2aab2cdf5886b2
+  languageName: node
+  linkType: hard
+
+"yargs@npm:^17.7.2":
+  version: 17.7.3
+  resolution: "yargs@npm:17.7.3"
+  dependencies:
+    cliui: "npm:^8.0.1"
+    escalade: "npm:^3.1.1"
+    get-caller-file: "npm:^2.0.5"
+    require-directory: "npm:^2.1.1"
+    string-width: "npm:^4.2.3"
+    y18n: "npm:^5.0.5"
+    yargs-parser: "npm:^21.1.1"
+  checksum: 10c0/7a28572f7e785a57886e34fdbddb9b28756dec552e1453d5f6e7cdd00ad8721a4e8c4321d33683f5e61cacb36ad43258adbb48396b71ec4ed14abee0fc0d0c1f
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -675,7 +675,6 @@ __metadata:
     husky: "npm:^9.0.0"
     msw: "npm:^2.15.0"
     object-to-formdata: "npm:^4.5.1"
-    p-throttle: "npm:^7.0.0"
     typescript: "npm:^7.0.2"
     vitest: "npm:^4.1.8"
     zod: "npm:^4.0.0"
@@ -1092,13 +1091,6 @@ __metadata:
   version: 1.4.3
   resolution: "outvariant@npm:1.4.3"
   checksum: 10c0/5976ca7740349cb8c71bd3382e2a762b1aeca6f33dc984d9d896acdf3c61f78c3afcf1bfe9cc633a7b3c4b295ec94d292048f83ea2b2594fae4496656eba992c
-  languageName: node
-  linkType: hard
-
-"p-throttle@npm:^7.0.0":
-  version: 7.0.0
-  resolution: "p-throttle@npm:7.0.0"
-  checksum: 10c0/7a9ca80826808b3d7f946369fc17a0ba020064c1bda9a5dfa74d2c9713f896576cdc4872bd61091ef2950d6a84072cac672bb1eb88a8b6a0c9e348d030623fc1
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- route the existing test suite through one strict, stateful MSW server
- use the reserved `api.jotform.test` hostname and fail on every unhandled request
- remove the Jotform API secret and request throttling from CI
- preserve the existing test organization, odd response shapes, and account-specific errors
- enable the history test now that its live 12-second latency is gone
- leave workflow triggers unchanged, including `branches: ['*']`

## Test diff

The existing `src/index.spec.ts` structure is unchanged apart from enabling `getHistory()`. The remaining diff removes the `vi` and `p-throttle` imports plus the five-line global fetch throttle. All endpoint mocking and state live in `test/mockServer.ts`.

## Root cause

The tests were integration tests against a shared Jotform account. Their live writes accumulated an undocumented, persistent `POST /label` creation quota across jobs. Jotform returned either `Creation rate limit exceeded, wait before trying to create more labels.` or a generic HTML 502 response. Slowing the suite did not address that shared mutable state.

## Compatibility behavior captured

The MSW fixture intentionally reproduces behavior already asserted or documented by the suite instead of normalizing it:

- bulk form creation returns one object rather than an array
- webhook creation returns a string-keyed ID-to-URL map
- question and submission deletion return endpoint-specific success strings
- report and label deletion return booleans
- label resource mutation returns resource arrays
- folder methods retain their exact deprecation errors
- subuser and report-detail handlers retain the exact authorization errors returned to this account

## Network isolation

- all client requests target `https://api.jotform.test`
- MSW uses `onUnhandledRequest: 'error'`
- CI no longer receives `JOTFORM_API_KEY`
- no handler bypasses to the network

## Validation

- `yarn biome check --write`
- `yarn unit` — 54 passed, 3 skips, under one second
- `yarn tsc`
- `yarn build`
- `yarn dedupe`
- refreshed push and pull-request workflows: all jobs passed